### PR TITLE
Make the shark.md work with a dot graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ $ patdiff -ascii specs/shark.md specs/shark.out.md
  |
 -|```shark-run:gdal-env
 +|```shark-run:gdal-env:8a1a508be0c5214b75f7e5a179206e5126cb9a2f772ec7ca050f58563085f364
- |$ gdalinfo --version > gdal.version
- |$ cat gdal.version
+ |$ gdalinfo --version > /data/gdal.version
+ |$ cat /data/gdal.version
 +|GDAL 3.6.4, released 2023/04/17
 +|
  |```

--- a/specs/shark.md
+++ b/specs/shark.md
@@ -18,8 +18,8 @@ using that environment.
 ## Shark Run
 
 ```shark-run:gdal-env
-$ gdalinfo --version > gdal.version
-$ cat gdal.version
+$ gdalinfo --version > /data/gdal.version
+$ cat /data/gdal.version
 ```
 
 Of course we can make use of the pretty good networking reproducibility.

--- a/specs/shark.out.md
+++ b/specs/shark.out.md
@@ -18,8 +18,8 @@ using that environment.
 ## Shark Run
 
 ```shark-run:gdal-env:8a1a508be0c5214b75f7e5a179206e5126cb9a2f772ec7ca050f58563085f364
-$ gdalinfo --version > gdal.version
-$ cat gdal.version
+$ gdalinfo --version > /data/gdal.version
+$ cat /data/gdal.version
 GDAL 3.6.4, released 2023/04/17
 
 ```

--- a/src/lib/command.ml
+++ b/src/lib/command.ml
@@ -46,7 +46,13 @@ let parse_rscript_command args =
   in
   { name; args; file_args = find_file_args args }
 
-let parse_generic_commmand name args =
+let parse_generic_commmand args =
+  let name =
+    match args with
+    | "$" :: x :: _ -> x
+    | x :: _ -> x
+    | _ -> "Unrecognised command"
+  in
   { name; args; file_args = find_file_args args }
 
 let of_string command_str =
@@ -55,7 +61,7 @@ let of_string command_str =
   | [] -> None
   | "python3" :: args -> Some (parse_python_command args)
   | "Rscript" :: args -> Some (parse_rscript_command args)
-  | name :: args -> Some (parse_generic_commmand name args)
+  | name :: args -> Some (parse_generic_commmand (name :: args))
 
 let name c = c.name
 let file_args c = c.file_args

--- a/src/lib/command.ml
+++ b/src/lib/command.ml
@@ -1,6 +1,11 @@
 open Astring
+open Sexplib.Conv
 
 type t = { name : string; args : string list; file_args : string list }
+[@@deriving sexp]
+
+let pp ppf t = Sexplib.Sexp.pp_hum ppf (sexp_of_t t)
+let v ~name ~args ~file_args = { name; args; file_args }
 
 let find_file_args args =
   (* gross liberties, we assume for now that any arg with a doubeldash might be a file. though ultimately this

--- a/src/test/test.ml
+++ b/src/test/test.ml
@@ -22,7 +22,6 @@ module Basic = struct
 end
 
 module CommandParsing = struct
-
   let test_python_command_module () =
     let testcase = "python3 -m some.module.code arg1 arg2" in
     let expected_name = "some.module.code" in
@@ -30,7 +29,9 @@ module CommandParsing = struct
     let test = Shark.Command.of_string testcase in
     match test with
     | None -> Alcotest.fail "Command parse failed"
-    | Some t -> Alcotest.(check string) "Command name" (Shark.Command.name t) expected_name
+    | Some t ->
+        Alcotest.(check string)
+          "Command name" (Shark.Command.name t) expected_name
 
   let test_python_command_direct () =
     let testcase = "python3 some/module/code.py arg1 arg2" in
@@ -39,7 +40,9 @@ module CommandParsing = struct
     let test = Shark.Command.of_string testcase in
     match test with
     | None -> Alcotest.fail "Command parse failed"
-    | Some t -> Alcotest.(check string) "Command name" (Shark.Command.name t) expected_name
+    | Some t ->
+        Alcotest.(check string)
+          "Command name" (Shark.Command.name t) expected_name
 
   let test_rscript_command_basic () =
     let testcase = "Rscript some/module/code.r arg1 arg2" in
@@ -48,7 +51,9 @@ module CommandParsing = struct
     let test = Shark.Command.of_string testcase in
     match test with
     | None -> Alcotest.fail "Command parse failed"
-    | Some t -> Alcotest.(check string) "Command name" (Shark.Command.name t) expected_name
+    | Some t ->
+        Alcotest.(check string)
+          "Command name" (Shark.Command.name t) expected_name
 
   let test_rscript_command_options () =
     let testcase = "Rscript --no-environ --save some/module/code.r arg1 arg2" in
@@ -57,7 +62,9 @@ module CommandParsing = struct
     let test = Shark.Command.of_string testcase in
     match test with
     | None -> Alcotest.fail "Command parse failed"
-    | Some t -> Alcotest.(check string) "Command name" (Shark.Command.name t) expected_name
+    | Some t ->
+        Alcotest.(check string)
+          "Command name" (Shark.Command.name t) expected_name
 
   let test_generic_command_basic () =
     let testcase = "docker arg1 arg2" in
@@ -66,7 +73,9 @@ module CommandParsing = struct
     let test = Shark.Command.of_string testcase in
     match test with
     | None -> Alcotest.fail "Command parse failed"
-    | Some t -> Alcotest.(check string) "Command name" (Shark.Command.name t) expected_name
+    | Some t ->
+        Alcotest.(check string)
+          "Command name" (Shark.Command.name t) expected_name
 
   let test_generic_command_basic_with_prefix () =
     let testcase = "$ docker arg1 arg2" in
@@ -75,17 +84,29 @@ module CommandParsing = struct
     let test = Shark.Command.of_string testcase in
     match test with
     | None -> Alcotest.fail "Command parse failed"
-    | Some t -> Alcotest.(check string) "Command name" (Shark.Command.name t) expected_name
+    | Some t ->
+        Alcotest.(check string)
+          "Command name" (Shark.Command.name t) expected_name
 
-  let tests = [
-    ("Basic python command parsing for module", `Quick, test_python_command_module) ;
-    ("Basic python command parsing for file", `Quick, test_python_command_direct) ;
-    ("Basic R command parsing", `Quick, test_rscript_command_basic) ;
-    ("Basic R command parsing with options", `Quick, test_rscript_command_options) ;
-    ("Basic command parsing", `Quick, test_generic_command_basic) ;
-    ("Basic command parsing with prefix", `Quick, test_generic_command_basic_with_prefix) ;
-  ]
-
+  let tests =
+    [
+      ( "Basic python command parsing for module",
+        `Quick,
+        test_python_command_module );
+      ( "Basic python command parsing for file",
+        `Quick,
+        test_python_command_direct );
+      ("Basic R command parsing", `Quick, test_rscript_command_basic);
+      ( "Basic R command parsing with options",
+        `Quick,
+        test_rscript_command_options );
+      ("Basic command parsing", `Quick, test_generic_command_basic);
+      ( "Basic command parsing with prefix",
+        `Quick,
+        test_generic_command_basic_with_prefix );
+    ]
 end
 
-let () = Alcotest.run "shark" [ ("basic", Basic.tests) ; ("command parsing", CommandParsing.tests) ]
+let () =
+  Alcotest.run "shark"
+    [ ("basic", Basic.tests); ("command parsing", CommandParsing.tests) ]

--- a/src/test/test.ml
+++ b/src/test/test.ml
@@ -21,4 +21,71 @@ module Basic = struct
   let tests = [ ("shark blocks", `Quick, test_shark_block) ]
 end
 
-let () = Alcotest.run "shark" [ ("basic", Basic.tests) ]
+module CommandParsing = struct
+
+  let test_python_command_module () =
+    let testcase = "python3 -m some.module.code arg1 arg2" in
+    let expected_name = "some.module.code" in
+
+    let test = Shark.Command.of_string testcase in
+    match test with
+    | None -> Alcotest.fail "Command parse failed"
+    | Some t -> Alcotest.(check string) "Command name" (Shark.Command.name t) expected_name
+
+  let test_python_command_direct () =
+    let testcase = "python3 some/module/code.py arg1 arg2" in
+    let expected_name = "code.py" in
+
+    let test = Shark.Command.of_string testcase in
+    match test with
+    | None -> Alcotest.fail "Command parse failed"
+    | Some t -> Alcotest.(check string) "Command name" (Shark.Command.name t) expected_name
+
+  let test_rscript_command_basic () =
+    let testcase = "Rscript some/module/code.r arg1 arg2" in
+    let expected_name = "code.r" in
+
+    let test = Shark.Command.of_string testcase in
+    match test with
+    | None -> Alcotest.fail "Command parse failed"
+    | Some t -> Alcotest.(check string) "Command name" (Shark.Command.name t) expected_name
+
+  let test_rscript_command_options () =
+    let testcase = "Rscript --no-environ --save some/module/code.r arg1 arg2" in
+    let expected_name = "code.r" in
+
+    let test = Shark.Command.of_string testcase in
+    match test with
+    | None -> Alcotest.fail "Command parse failed"
+    | Some t -> Alcotest.(check string) "Command name" (Shark.Command.name t) expected_name
+
+  let test_generic_command_basic () =
+    let testcase = "docker arg1 arg2" in
+    let expected_name = "docker" in
+
+    let test = Shark.Command.of_string testcase in
+    match test with
+    | None -> Alcotest.fail "Command parse failed"
+    | Some t -> Alcotest.(check string) "Command name" (Shark.Command.name t) expected_name
+
+  let test_generic_command_basic_with_prefix () =
+    let testcase = "$ docker arg1 arg2" in
+    let expected_name = "docker" in
+
+    let test = Shark.Command.of_string testcase in
+    match test with
+    | None -> Alcotest.fail "Command parse failed"
+    | Some t -> Alcotest.(check string) "Command name" (Shark.Command.name t) expected_name
+
+  let tests = [
+    ("Basic python command parsing for module", `Quick, test_python_command_module) ;
+    ("Basic python command parsing for file", `Quick, test_python_command_direct) ;
+    ("Basic R command parsing", `Quick, test_rscript_command_basic) ;
+    ("Basic R command parsing with options", `Quick, test_rscript_command_options) ;
+    ("Basic command parsing", `Quick, test_generic_command_basic) ;
+    ("Basic command parsing with prefix", `Quick, test_generic_command_basic_with_prefix) ;
+  ]
+
+end
+
+let () = Alcotest.run "shark" [ ("basic", Basic.tests) ; ("command parsing", CommandParsing.tests) ]

--- a/src/test/test.ml
+++ b/src/test/test.ml
@@ -22,71 +22,67 @@ module Basic = struct
 end
 
 module CommandParsing = struct
+  let command = Alcotest.of_pp Shark.Command.pp
+
   let test_python_command_module () =
     let testcase = "python3 -m some.module.code arg1 arg2" in
-    let expected_name = "some.module.code" in
-
+    let expected =
+      Shark.Command.v ~name:"some.module.code"
+        ~args:[ "-m"; "some.module.code"; "arg1"; "arg2" ]
+        ~file_args:[]
+    in
     let test = Shark.Command.of_string testcase in
-    match test with
-    | None -> Alcotest.fail "Command parse failed"
-    | Some t ->
-        Alcotest.(check string)
-          "Command name" (Shark.Command.name t) expected_name
+    Alcotest.(check (option command)) "Command" test (Some expected)
 
   let test_python_command_direct () =
     let testcase = "python3 some/module/code.py arg1 arg2" in
-    let expected_name = "code.py" in
-
+    let expected =
+      Shark.Command.v ~name:"code.py"
+        ~args:[ "some/module/code.py"; "arg1"; "arg2" ]
+        ~file_args:[]
+    in
     let test = Shark.Command.of_string testcase in
-    match test with
-    | None -> Alcotest.fail "Command parse failed"
-    | Some t ->
-        Alcotest.(check string)
-          "Command name" (Shark.Command.name t) expected_name
+    Alcotest.(check (option command)) "Command" test (Some expected)
 
   let test_rscript_command_basic () =
     let testcase = "Rscript some/module/code.r arg1 arg2" in
-    let expected_name = "code.r" in
-
+    let expected =
+      Shark.Command.v ~name:"code.r"
+        ~args:[ "some/module/code.r"; "arg1"; "arg2" ]
+        ~file_args:[]
+    in
     let test = Shark.Command.of_string testcase in
-    match test with
-    | None -> Alcotest.fail "Command parse failed"
-    | Some t ->
-        Alcotest.(check string)
-          "Command name" (Shark.Command.name t) expected_name
+    Alcotest.(check (option command)) "Command" test (Some expected)
 
   let test_rscript_command_options () =
     let testcase = "Rscript --no-environ --save some/module/code.r arg1 arg2" in
-    let expected_name = "code.r" in
-
+    let expected =
+      Shark.Command.v ~name:"code.r"
+        ~args:[ "--no-environ"; "--save"; "some/module/code.r"; "arg1"; "arg2" ]
+        ~file_args:[]
+    in
     let test = Shark.Command.of_string testcase in
-    match test with
-    | None -> Alcotest.fail "Command parse failed"
-    | Some t ->
-        Alcotest.(check string)
-          "Command name" (Shark.Command.name t) expected_name
+    Alcotest.(check (option command)) "Command" test (Some expected)
 
   let test_generic_command_basic () =
     let testcase = "docker arg1 arg2" in
-    let expected_name = "docker" in
-
+    let expected =
+      Shark.Command.v ~name:"docker"
+        ~args:[ "docker"; "arg1"; "arg2" ]
+        ~file_args:[]
+    in
     let test = Shark.Command.of_string testcase in
-    match test with
-    | None -> Alcotest.fail "Command parse failed"
-    | Some t ->
-        Alcotest.(check string)
-          "Command name" (Shark.Command.name t) expected_name
+    Alcotest.(check (option command)) "Command" test (Some expected)
 
   let test_generic_command_basic_with_prefix () =
     let testcase = "$ docker arg1 arg2" in
-    let expected_name = "docker" in
-
+    let expected =
+      Shark.Command.v ~name:"docker"
+        ~args:[ "$"; "docker"; "arg1"; "arg2" ]
+        ~file_args:[]
+    in
     let test = Shark.Command.of_string testcase in
-    match test with
-    | None -> Alcotest.fail "Command parse failed"
-    | Some t ->
-        Alcotest.(check string)
-          "Command name" (Shark.Command.name t) expected_name
+    Alcotest.(check (option command)) "Command" test (Some expected)
 
   let tests =
     [


### PR DESCRIPTION
Changes 2 things:

1. Makes command.ml skip the $ on generic commands
2. Adds /data to the example paths in shark.md