### PR TITLE
Detect subpaths for dirs

### DIFF
--- a/src/lib/ast.ml
+++ b/src/lib/ast.ml
@@ -11,16 +11,12 @@ module DataFile = struct
     let wildcard =
       match subpath with
       | None -> false
-      | Some p ->
-          let last_char =
-            String.Sub.to_string (String.sub ~start:(String.length p - 1) p)
-          in
-          last_char = "*"
+      | Some p -> Char.equal p.[String.length p - 1] '*'
     in
     if wildcard then
       {
         id;
-        path = String.Sub.to_string (String.sub ~stop:(String.length path) path);
+        path = String.Sub.to_string (String.sub ~stop:((String.length path) - 1) path);
         subpath = None;
         wildcard = true;
       }
@@ -33,8 +29,9 @@ module DataFile = struct
     | false -> d.path
     | true ->
         let p = d.path in
-        let last_char = String.sub ~start:(String.length p - 1) p in
-        if String.Sub.to_string last_char = "/" then p else p ^ "/"
+        match Char.equal p.[String.length p - 1] '/' with
+        | true -> p
+        | false -> p ^ "/"
 
   let path_nc d = d.path
   let subpath d = d.subpath
@@ -90,11 +87,10 @@ let find_matching_datafile datafile_map path =
   | None ->
       (* No full match, but can we find a prefix dir *)
       List.fold_left
-        (fun acc i ->
+        (fun acc (ipath, df) ->
           match acc with
           | Some x -> Some x
           | None -> (
-              let ipath, df = i in
               match DataFile.is_dir df with
               | false -> None
               | true -> (

--- a/src/lib/ast.ml
+++ b/src/lib/ast.ml
@@ -7,7 +7,7 @@ module DataFile = struct
 
   let pp ppf t = Sexplib.Sexp.pp_hum ppf (sexp_of_t t)
 
-  let v ?(subpath = None) id path =
+  let v ?subpath id path =
     let wildcard =
       match subpath with
       | None -> false
@@ -103,9 +103,8 @@ let find_matching_datafile datafile_map path =
                       Some
                         (DataFile.v
                            ~subpath:
-                             (Some
-                                (String.Sub.to_string
-                                   (String.sub ~start:(String.length ipath) path)))
+                             (String.Sub.to_string
+                                (String.sub ~start:(String.length ipath) path))
                            (DataFile.id df) (DataFile.path df))
                   | false -> None)))
         None datafile_map

--- a/src/lib/ast.mli
+++ b/src/lib/ast.mli
@@ -15,20 +15,24 @@ module DataFile : sig
   val id : t -> int
   val path : t -> string
   val subpath : t -> string option
+  val is_wildcard : t -> bool
   val compare : t -> t -> int
 end
 
 module Leaf : sig
   (** A Leaf is an atomic exection unit the in the pipeline graph. *)
 
+  type style = Command | Map
   type t
 
-  val create : int -> Command.t -> DataFile.t list -> DataFile.t list -> t
+  val create :
+    int -> Command.t -> style -> DataFile.t list -> DataFile.t list -> t
   (** Creats a new leaf node, taking an integer identifier, the command to execute
       and a list of inputs and a list of outputs. *)
 
   val id : t -> int
   val command : t -> Command.t
+  val command_style : t -> style
   val inputs : t -> DataFile.t list
   val outputs : t -> DataFile.t list
 end

--- a/src/lib/ast.mli
+++ b/src/lib/ast.mli
@@ -4,32 +4,13 @@ The AST is the logical representation of the workflow described in a
 sharkdown file, including the structure of groups (aka basic blocks
 in PL, but block is an overloaded term in this context). *)
 
-module DataFile : sig
-  (** A named file/directory that acts as an input and/or output of a process. *)
-
-  type t
-
-  val v : ?subpath:string -> int -> string -> t
-  (** Creates a new datafile with an integer ID and a file path. *)
-
-  val pp : t Fmt.t
-  (** A pretty printer for datafiles. *)
-
-  val id : t -> int
-  val path : t -> string
-  val subpath : t -> string option
-  val is_wildcard : t -> bool
-  val is_dir : t -> bool
-  val compare : t -> t -> int
-end
-
 module Leaf : sig
   (** A Leaf is an atomic exection unit the in the pipeline graph. *)
 
   type style = Command | Map
   type t
 
-  val v : int -> Command.t -> style -> DataFile.t list -> DataFile.t list -> t
+  val v : int -> Command.t -> style -> Datafile.t list -> Datafile.t list -> t
   (** Creats a new leaf node, taking an integer identifier, the command to execute
       and a list of inputs and a list of outputs. *)
 
@@ -39,8 +20,8 @@ module Leaf : sig
   val id : t -> int
   val command : t -> Command.t
   val command_style : t -> style
-  val inputs : t -> DataFile.t list
-  val outputs : t -> DataFile.t list
+  val inputs : t -> Datafile.t list
+  val outputs : t -> Datafile.t list
 end
 
 module CommandGroup : sig

--- a/src/lib/ast.mli
+++ b/src/lib/ast.mli
@@ -9,11 +9,12 @@ module DataFile : sig
 
   type t
 
-  val create : int -> string -> t
+  val create : ?subpath:string option -> int -> string -> t
   (** Creates a new datafile with an integer ID and a file path. *)
 
   val id : t -> int
   val path : t -> string
+  val subpath : t -> string option
   val compare : t -> t -> int
 end
 

--- a/src/lib/ast.mli
+++ b/src/lib/ast.mli
@@ -9,7 +9,7 @@ module DataFile : sig
 
   type t
 
-  val v : ?subpath:string option -> int -> string -> t
+  val v : ?subpath:string -> int -> string -> t
   (** Creates a new datafile with an integer ID and a file path. *)
 
   val pp : t Fmt.t

--- a/src/lib/ast.mli
+++ b/src/lib/ast.mli
@@ -9,13 +9,17 @@ module DataFile : sig
 
   type t
 
-  val create : ?subpath:string option -> int -> string -> t
+  val v : ?subpath:string option -> int -> string -> t
   (** Creates a new datafile with an integer ID and a file path. *)
+
+  val pp : t Fmt.t
+  (** A pretty printer for datafiles. *)
 
   val id : t -> int
   val path : t -> string
   val subpath : t -> string option
   val is_wildcard : t -> bool
+  val is_dir : t -> bool
   val compare : t -> t -> int
 end
 
@@ -25,10 +29,12 @@ module Leaf : sig
   type style = Command | Map
   type t
 
-  val create :
-    int -> Command.t -> style -> DataFile.t list -> DataFile.t list -> t
+  val v : int -> Command.t -> style -> DataFile.t list -> DataFile.t list -> t
   (** Creats a new leaf node, taking an integer identifier, the command to execute
       and a list of inputs and a list of outputs. *)
+
+  val pp : t Fmt.t
+  (** A pretty printer for leaves. *)
 
   val id : t -> int
   val command : t -> Command.t
@@ -42,8 +48,11 @@ module CommandGroup : sig
 
   type t
 
-  val create : string -> Leaf.t list -> t
+  val v : string -> Leaf.t list -> t
   (** Creates a command group made up of a series of leaf nodes and given a name. *)
+
+  val pp : t Fmt.t
+  (** A pretty printer for command groups. *)
 
   val name : t -> string
   val children : t -> Leaf.t list

--- a/src/lib/command.mli
+++ b/src/lib/command.mli
@@ -1,0 +1,10 @@
+type t [@@deriving sexp]
+
+val v : name:string -> args:string list -> file_args:Fpath.t list -> t
+
+val pp : t Fmt.t
+(** A pretty printer for blocks. *)
+
+val of_string : string -> t option
+val name : t -> string
+val file_args : t -> Fpath.t list

--- a/src/lib/datafile.ml
+++ b/src/lib/datafile.ml
@@ -1,0 +1,33 @@
+open Astring
+open Sexplib.Conv
+
+type path = Fpath.t
+
+let path_of_sexp = function
+  | Ppx_sexp_conv_lib.Sexp.Atom s -> Fpath.v s
+  | List _ -> Fpath.v ""
+
+let sexp_of_path v = Ppx_sexp_conv_lib.Sexp.Atom (Fpath.to_string v)
+
+type t = { id : int; path : path; subpath : string option; wildcard : bool }
+[@@deriving sexp]
+
+type err = InvalidPath of string | InvalidSubpath of string
+
+let pp ppf t = Sexplib.Sexp.pp_hum ppf (sexp_of_t t)
+
+let v ?subpath id path =
+  let wildcard =
+    match subpath with
+    | None -> false
+    | Some p -> Char.equal p.[String.length p - 1] '*'
+  in
+  if wildcard then { id; path; subpath = None; wildcard = true }
+  else { id; path; subpath; wildcard = false }
+
+let id d = d.id
+let path d = d.path
+let subpath d = d.subpath
+let is_wildcard d = d.wildcard
+let compare a b = Int.compare a.id b.id
+let is_dir d = Fpath.is_dir_path d.path

--- a/src/lib/datafile.ml
+++ b/src/lib/datafile.ml
@@ -12,8 +12,6 @@ let sexp_of_path v = Ppx_sexp_conv_lib.Sexp.Atom (Fpath.to_string v)
 type t = { id : int; path : path; subpath : string option; wildcard : bool }
 [@@deriving sexp]
 
-type err = InvalidPath of string | InvalidSubpath of string
-
 let pp ppf t = Sexplib.Sexp.pp_hum ppf (sexp_of_t t)
 
 let v ?subpath id path =

--- a/src/lib/datafile.mli
+++ b/src/lib/datafile.mli
@@ -1,7 +1,6 @@
 (** A named file/directory that acts as an input and/or output of a process. *)
 
 type t [@@deriving sexp]
-type err = InvalidPath of string | InvalidSubpath of string
 
 val v : ?subpath:string -> int -> Fpath.t -> t
 (** Creates a new datafile with an integer ID and a file path. *)

--- a/src/lib/datafile.mli
+++ b/src/lib/datafile.mli
@@ -1,0 +1,17 @@
+(** A named file/directory that acts as an input and/or output of a process. *)
+
+type t [@@deriving sexp]
+type err = InvalidPath of string | InvalidSubpath of string
+
+val v : ?subpath:string -> int -> Fpath.t -> t
+(** Creates a new datafile with an integer ID and a file path. *)
+
+val pp : t Fmt.t
+(** A pretty printer for datafiles. *)
+
+val id : t -> int
+val path : t -> Fpath.t
+val subpath : t -> string option
+val is_wildcard : t -> bool
+val is_dir : t -> bool
+val compare : t -> t -> int

--- a/src/lib/dotrenderer.ml
+++ b/src/lib/dotrenderer.ml
@@ -1,6 +1,5 @@
 open Astring
-module DataFile = Ast.DataFile
-module DataFileSet = Set.Make (DataFile)
+module DatafileSet = Set.Make (Datafile)
 
 (* In theory this could be a recursive structure that attempts to maintain the
     heirarchy of the document, markdown doesn't enforce that the section levels
@@ -17,12 +16,12 @@ let render_command_to_dot ppf command =
   List.iter
     (fun datafile ->
       let label =
-        match DataFile.subpath datafile with
+        match Datafile.subpath datafile with
         | Some x -> Printf.sprintf ",label=\"%s\"" x
         | None -> ""
       in
       Format.fprintf ppf "\tn%d->n%d[penwidth=\"2.0\"%s];\n"
-        (DataFile.id datafile) process_index label)
+        (Datafile.id datafile) process_index label)
     (Ast.Leaf.inputs command);
   let shape =
     match Ast.Leaf.command_style command with
@@ -34,13 +33,14 @@ let render_command_to_dot ppf command =
   List.iter
     (fun datafile ->
       Format.fprintf ppf "\tn%d->n%d[penwidth=\"2.0\"];\n" process_index
-        (DataFile.id datafile))
+        (Datafile.id datafile))
     (Ast.Leaf.outputs command);
   Format.fprintf ppf "\n"
 
 let datafile_to_dot ppf datafile =
   Format.fprintf ppf "\tn%d[shape=\"cylinder\",label=\"%s\"];\n"
-    (DataFile.id datafile) (DataFile.path datafile)
+    (Datafile.id datafile)
+    (Fpath.to_string (Datafile.path datafile))
 
 let render_ast_to_dot ppf ast : unit =
   Format.fprintf ppf "digraph{\n";
@@ -54,8 +54,8 @@ let render_ast_to_dot ppf ast : unit =
           List.concat [ inputs; outputs ])
         commands)
     ast
-  |> DataFileSet.of_list
-  |> DataFileSet.iter (datafile_to_dot ppf);
+  |> DatafileSet.of_list
+  |> DatafileSet.iter (datafile_to_dot ppf);
 
   List.iteri
     (fun i group ->

--- a/src/lib/dotrenderer.ml
+++ b/src/lib/dotrenderer.ml
@@ -16,8 +16,13 @@ let render_command_to_dot ppf command =
   let process_index = Ast.Leaf.id command in
   List.iter
     (fun datafile ->
-      Format.fprintf ppf "\tn%d->n%d[penwidth=\"2.0\"];\n"
-        (DataFile.id datafile) process_index)
+      let label =
+        match DataFile.subpath datafile with
+        | Some x -> Printf.sprintf ",label=\"%s\"" x
+        | None -> ""
+      in
+      Format.fprintf ppf "\tn%d->n%d[penwidth=\"2.0\"%s];\n"
+        (DataFile.id datafile) process_index label)
     (Ast.Leaf.inputs command);
   Format.fprintf ppf "\tn%d[shape=\"%s\",label=\"%s\"];\n" process_index "box"
     (Uri.pct_encode (Command.name (Ast.Leaf.command command)));

--- a/src/lib/dotrenderer.ml
+++ b/src/lib/dotrenderer.ml
@@ -24,7 +24,12 @@ let render_command_to_dot ppf command =
       Format.fprintf ppf "\tn%d->n%d[penwidth=\"2.0\"%s];\n"
         (DataFile.id datafile) process_index label)
     (Ast.Leaf.inputs command);
-  Format.fprintf ppf "\tn%d[shape=\"%s\",label=\"%s\"];\n" process_index "box"
+  let shape =
+    match Ast.Leaf.command_style command with
+    | Command -> "box"
+    | Map -> "box3d"
+  in
+  Format.fprintf ppf "\tn%d[shape=\"%s\",label=\"%s\"];\n" process_index shape
     (Uri.pct_encode (Command.name (Ast.Leaf.command command)));
   List.iter
     (fun datafile ->

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -1,6 +1,16 @@
 (library
  (name shark)
- (libraries eio cohttp-eio str yaml lwt_eio cmarkit obuilder htmlit routes)
+ (libraries
+  eio
+  cohttp-eio
+  str
+  yaml
+  lwt_eio
+  cmarkit
+  obuilder
+  htmlit
+  routes
+  fpath)
  (preprocess
   (pps ppx_sexp_conv)))
 

--- a/src/lib/frontmatter.mli
+++ b/src/lib/frontmatter.mli
@@ -1,0 +1,8 @@
+type t [@@deriving sexp]
+
+val pp : t Fmt.t
+val v : (string * string list) list -> Fpath.t list -> t
+val empty : t
+val of_string : string -> (t, [ `Msg of string ]) result
+val variables : t -> (string * string list) list
+val inputs : t -> Fpath.t list

--- a/src/test/datafile.ml
+++ b/src/test/datafile.ml
@@ -1,0 +1,31 @@
+let test_basic_file_path () =
+  let testcase = Fpath.v "/data/test/example.tif" in
+  let test = Shark.Datafile.v 42 testcase in
+  Alcotest.(check int) "Same id" 42 (Shark.Datafile.id test);
+  Alcotest.(check string)
+    "Same path" (Fpath.to_string testcase)
+    (Fpath.to_string (Shark.Datafile.path test));
+  Alcotest.(check (option string))
+    "No subpath" None
+    (Shark.Datafile.subpath test);
+  Alcotest.(check bool) "Isn't wildcard" false (Shark.Datafile.is_wildcard test);
+  Alcotest.(check bool) "Isn't dir" false (Shark.Datafile.is_dir test)
+
+let test_basic_dir_with_wildcard () =
+  let testcase = Fpath.v "/data/test/" in
+  let test = Shark.Datafile.v ~subpath:"*" 42 testcase in
+  Alcotest.(check int) "Same id" 42 (Shark.Datafile.id test);
+  Alcotest.(check string)
+    "Same path" (Fpath.to_string testcase)
+    (Fpath.to_string (Shark.Datafile.path test));
+  Alcotest.(check (option string))
+    "No subpath" None
+    (Shark.Datafile.subpath test);
+  Alcotest.(check bool) "Is wildcard" true (Shark.Datafile.is_wildcard test);
+  Alcotest.(check bool) "Is dir" true (Shark.Datafile.is_dir test)
+
+let tests =
+  [
+    ("Basic file", `Quick, test_basic_file_path);
+    ("Canonical dir with wildcard", `Quick, test_basic_dir_with_wildcard);
+  ]

--- a/src/test/dune
+++ b/src/test/dune
@@ -1,3 +1,3 @@
 (test
  (name test)
- (libraries alcotest shark))
+ (libraries alcotest shark fpath))

--- a/src/test/expect/test_dot.expected
+++ b/src/test/expect/test_dot.expected
@@ -1,32 +1,32 @@
 digraph{
 	n0[shape="cylinder",label="/data/tmf/project_boundaries/123.geojson"];
-	n1[shape="cylinder",label="/data/tmf/project_boundaries"];
-	n2[shape="cylinder",label="/data/tmf/jrc/zips"];
-	n3[shape="cylinder",label="/data/tmf/jrc/tif"];
-	n5[shape="cylinder",label="/data/tmf/fcc-cpcs"];
+	n1[shape="cylinder",label="/data/tmf/project_boundaries/"];
+	n2[shape="cylinder",label="/data/tmf/jrc/zips/"];
+	n3[shape="cylinder",label="/data/tmf/jrc/tif/"];
+	n5[shape="cylinder",label="/data/tmf/fcc-cpcs/"];
 	n7[shape="cylinder",label="/data/tmf/ecoregions/ecoregions.geojson"];
-	n9[shape="cylinder",label="/data/tmf/ecoregions"];
+	n9[shape="cylinder",label="/data/tmf/ecoregions/"];
 	n11[shape="cylinder",label="/data/tmf/access/raw.tif"];
-	n13[shape="cylinder",label="/data/tmf/access"];
+	n13[shape="cylinder",label="/data/tmf/access/"];
 	n15[shape="cylinder",label="/data/tmf/osm_borders.geojson"];
 	n17[shape="cylinder",label="/data/tmf/123/buffer.geojson"];
 	n19[shape="cylinder",label="/data/tmf/123/leakage.geojson"];
 	n21[shape="cylinder",label="/data/tmf/123/luc.tif"];
-	n23[shape="cylinder",label="/data/tmf/gedi"];
+	n23[shape="cylinder",label="/data/tmf/gedi/"];
 	n26[shape="cylinder",label="/data/tmf/123/carbon-density.csv"];
 	n28[shape="cylinder",label="/data/tmf/123/country-list.json"];
 	n30[shape="cylinder",label="/data/tmf/123/matching-area.geojson"];
-	n32[shape="cylinder",label="/data/tmf/srtm/zip"];
-	n33[shape="cylinder",label="/data/tmf/srtm/tif"];
-	n35[shape="cylinder",label="/data/tmf/slopes"];
-	n37[shape="cylinder",label="/data/tmf/rescaled-elevation"];
-	n39[shape="cylinder",label="/data/tmf/rescaled-slopes"];
+	n32[shape="cylinder",label="/data/tmf/srtm/zip/"];
+	n33[shape="cylinder",label="/data/tmf/srtm/tif/"];
+	n35[shape="cylinder",label="/data/tmf/slopes/"];
+	n37[shape="cylinder",label="/data/tmf/rescaled-elevation/"];
+	n39[shape="cylinder",label="/data/tmf/rescaled-slopes/"];
 	n41[shape="cylinder",label="/data/tmf/123/countries.tif"];
 	n43[shape="cylinder",label="/data/tmf/123/k.parquet"];
-	n45[shape="cylinder",label="/data/tmf/123/matches"];
+	n45[shape="cylinder",label="/data/tmf/123/matches/"];
 	n47[shape="cylinder",label="/data/tmf/123/matches.tif"];
 	n49[shape="cylinder",label="/data/tmf/123/matches.parquet"];
-	n51[shape="cylinder",label="/data/tmf/123/pairs"];
+	n51[shape="cylinder",label="/data/tmf/123/pairs/"];
 	n53[shape="cylinder",label="/data/tmf/123/additionality.csv"];
 subgraph "cluster_0" {
 	label = "JRC"

--- a/src/test/expect/test_dot.expected
+++ b/src/test/expect/test_dot.expected
@@ -1,32 +1,32 @@
 digraph{
 	n0[shape="cylinder",label="/data/tmf/project_boundaries/123.geojson"];
-	n1[shape="cylinder",label="/data/tmf/project_boundaries/"];
-	n2[shape="cylinder",label="/data/tmf/jrc/zips/"];
-	n3[shape="cylinder",label="/data/tmf/jrc/tif/"];
-	n5[shape="cylinder",label="/data/tmf/fcc-cpcs/"];
+	n1[shape="cylinder",label="/data/tmf/project_boundaries"];
+	n2[shape="cylinder",label="/data/tmf/jrc/zips"];
+	n3[shape="cylinder",label="/data/tmf/jrc/tif"];
+	n5[shape="cylinder",label="/data/tmf/fcc-cpcs"];
 	n7[shape="cylinder",label="/data/tmf/ecoregions/ecoregions.geojson"];
-	n9[shape="cylinder",label="/data/tmf/ecoregions/"];
+	n9[shape="cylinder",label="/data/tmf/ecoregions"];
 	n11[shape="cylinder",label="/data/tmf/access/raw.tif"];
-	n13[shape="cylinder",label="/data/tmf/access/"];
+	n13[shape="cylinder",label="/data/tmf/access"];
 	n15[shape="cylinder",label="/data/tmf/osm_borders.geojson"];
 	n17[shape="cylinder",label="/data/tmf/123/buffer.geojson"];
 	n19[shape="cylinder",label="/data/tmf/123/leakage.geojson"];
 	n21[shape="cylinder",label="/data/tmf/123/luc.tif"];
-	n23[shape="cylinder",label="/data/tmf/gedi/"];
+	n23[shape="cylinder",label="/data/tmf/gedi"];
 	n26[shape="cylinder",label="/data/tmf/123/carbon-density.csv"];
 	n28[shape="cylinder",label="/data/tmf/123/country-list.json"];
 	n30[shape="cylinder",label="/data/tmf/123/matching-area.geojson"];
-	n32[shape="cylinder",label="/data/tmf/srtm/zip/"];
-	n33[shape="cylinder",label="/data/tmf/srtm/tif/"];
-	n35[shape="cylinder",label="/data/tmf/slopes/"];
-	n37[shape="cylinder",label="/data/tmf/rescaled-elevation/"];
-	n39[shape="cylinder",label="/data/tmf/rescaled-slopes/"];
+	n32[shape="cylinder",label="/data/tmf/srtm/zip"];
+	n33[shape="cylinder",label="/data/tmf/srtm/tif"];
+	n35[shape="cylinder",label="/data/tmf/slopes"];
+	n37[shape="cylinder",label="/data/tmf/rescaled-elevation"];
+	n39[shape="cylinder",label="/data/tmf/rescaled-slopes"];
 	n41[shape="cylinder",label="/data/tmf/123/countries.tif"];
 	n43[shape="cylinder",label="/data/tmf/123/k.parquet"];
-	n45[shape="cylinder",label="/data/tmf/123/matches/"];
+	n45[shape="cylinder",label="/data/tmf/123/matches"];
 	n47[shape="cylinder",label="/data/tmf/123/matches.tif"];
 	n49[shape="cylinder",label="/data/tmf/123/matches.parquet"];
-	n51[shape="cylinder",label="/data/tmf/123/pairs/"];
+	n51[shape="cylinder",label="/data/tmf/123/pairs"];
 	n53[shape="cylinder",label="/data/tmf/123/additionality.csv"];
 subgraph "cluster_0" {
 	label = "JRC"

--- a/src/test/frontmatter.ml
+++ b/src/test/frontmatter.ml
@@ -1,0 +1,39 @@
+let frontmatter = Alcotest.of_pp Shark.Frontmatter.pp
+
+let test_empty () =
+  let testcase = "" in
+  match Shark.Frontmatter.of_string testcase with
+  | Error e ->
+      Alcotest.fail (Printf.sprintf "Failed %s" (match e with `Msg x -> x))
+  | Ok fm ->
+      Alcotest.(check frontmatter) "Empty expected" Shark.Frontmatter.empty fm
+
+let test_inputs () =
+  let testcase =
+    {|
+inputs:
+- /data/stuff
+- /data/other/
+- /data/file.txt
+  |}
+  in
+  match Shark.Frontmatter.of_string testcase with
+  | Error e ->
+      Alcotest.fail (Printf.sprintf "Failed %s" (match e with `Msg x -> x))
+  | Ok fm ->
+      let expected =
+        Shark.Frontmatter.v
+          [ ("inputs", [ "/data/stuff"; "/data/other/"; "/data/file.txt" ]) ]
+          [
+            Fpath.v "/data/stuff";
+            Fpath.v "/data/other/";
+            Fpath.v "/data/file.txt";
+          ]
+      in
+      Alcotest.(check frontmatter) "Empty expected" expected fm
+
+let tests =
+  [
+    ("empty front matter", `Quick, test_empty);
+    ("simple input list", `Quick, test_inputs);
+  ]

--- a/src/test/frontmatter.ml
+++ b/src/test/frontmatter.ml
@@ -1,12 +1,12 @@
+open Import
+
 let frontmatter = Alcotest.of_pp Shark.Frontmatter.pp
 
 let test_empty () =
   let testcase = "" in
-  match Shark.Frontmatter.of_string testcase with
-  | Error e ->
-      Alcotest.fail (Printf.sprintf "Failed %s" (match e with `Msg x -> x))
-  | Ok fm ->
-      Alcotest.(check frontmatter) "Empty expected" Shark.Frontmatter.empty fm
+  let res = Shark.Frontmatter.of_string testcase in
+  Alcotest.(check (result frontmatter msg))
+    "Empty expected" (Ok Shark.Frontmatter.empty) res
 
 let test_inputs () =
   let testcase =
@@ -17,20 +17,15 @@ inputs:
 - /data/file.txt
   |}
   in
-  match Shark.Frontmatter.of_string testcase with
-  | Error e ->
-      Alcotest.fail (Printf.sprintf "Failed %s" (match e with `Msg x -> x))
-  | Ok fm ->
-      let expected =
-        Shark.Frontmatter.v
-          [ ("inputs", [ "/data/stuff"; "/data/other/"; "/data/file.txt" ]) ]
-          [
-            Fpath.v "/data/stuff";
-            Fpath.v "/data/other/";
-            Fpath.v "/data/file.txt";
-          ]
-      in
-      Alcotest.(check frontmatter) "Empty expected" expected fm
+  let res = Shark.Frontmatter.of_string testcase in
+  let expected =
+    Shark.Frontmatter.v
+      [ ("inputs", [ "/data/stuff"; "/data/other/"; "/data/file.txt" ]) ]
+      [
+        Fpath.v "/data/stuff"; Fpath.v "/data/other/"; Fpath.v "/data/file.txt";
+      ]
+  in
+  Alcotest.(check (result frontmatter msg)) "Empty expected" (Ok expected) res
 
 let tests =
   [

--- a/src/test/import.ml
+++ b/src/test/import.ml
@@ -1,0 +1,2 @@
+let msg : [ `Msg of string ] Alcotest.testable =
+  Alcotest.of_pp (fun ppf (`Msg m) -> Fmt.pf ppf "msg: %s" m)

--- a/src/test/test.ml
+++ b/src/test/test.ml
@@ -103,6 +103,80 @@ module CommandParsing = struct
     ]
 end
 
+module DataFile = struct
+  (* let datafile = Alcotest.of_pp Shark.Ast.DataFile.pp *)
+
+  let test_basic_file_path () =
+    let testcase = "/data/test/example.tif" in
+    let test = Shark.Ast.DataFile.v 42 testcase in
+    Alcotest.(check int) "Same id" 42 (Shark.Ast.DataFile.id test);
+    Alcotest.(check string) "Same path" testcase (Shark.Ast.DataFile.path test);
+    Alcotest.(check (option string))
+      "No subpath" None
+      (Shark.Ast.DataFile.subpath test);
+    Alcotest.(check bool)
+      "Isn't wildcard" false
+      (Shark.Ast.DataFile.is_wildcard test);
+    Alcotest.(check bool) "Isn't dir" false (Shark.Ast.DataFile.is_dir test)
+
+  let test_basic_dir_noncanonical () =
+    let testcase = "/data/test" in
+    let test = Shark.Ast.DataFile.v 42 testcase in
+    Alcotest.(check int) "Same id" 42 (Shark.Ast.DataFile.id test);
+    Alcotest.(check string)
+      "Extended path" "/data/test/"
+      (Shark.Ast.DataFile.path test);
+    Alcotest.(check (option string))
+      "No subpath" None
+      (Shark.Ast.DataFile.subpath test);
+    Alcotest.(check bool)
+      "Isn't wildcard" false
+      (Shark.Ast.DataFile.is_wildcard test);
+    Alcotest.(check bool) "Is dir" true (Shark.Ast.DataFile.is_dir test)
+
+  let test_basic_dir_canonical () =
+    let testcase = "/data/test/" in
+    let test = Shark.Ast.DataFile.v 42 testcase in
+    Alcotest.(check int) "Same id" 42 (Shark.Ast.DataFile.id test);
+    Alcotest.(check string) "Same path" testcase (Shark.Ast.DataFile.path test);
+    Alcotest.(check (option string))
+      "No subpath" None
+      (Shark.Ast.DataFile.subpath test);
+    Alcotest.(check bool)
+      "Isn't wildcard" false
+      (Shark.Ast.DataFile.is_wildcard test);
+    Alcotest.(check bool) "Is dir" true (Shark.Ast.DataFile.is_dir test)
+
+  let test_basic_dir_canonical_with_wildcard () =
+    let testcase = "/data/test/" in
+    let test = Shark.Ast.DataFile.v ~subpath:(Some "*") 42 testcase in
+    Alcotest.(check int) "Same id" 42 (Shark.Ast.DataFile.id test);
+    Alcotest.(check string)
+      "Extended path" "/data/test/"
+      (Shark.Ast.DataFile.path test);
+    Alcotest.(check (option string))
+      "No subpath" None
+      (Shark.Ast.DataFile.subpath test);
+    Alcotest.(check bool)
+      "Is wildcard" true
+      (Shark.Ast.DataFile.is_wildcard test);
+    Alcotest.(check bool) "Is dir" true (Shark.Ast.DataFile.is_dir test)
+
+  let tests =
+    [
+      ("Basic file", `Quick, test_basic_file_path);
+      ("Non-canonical dir", `Quick, test_basic_dir_noncanonical);
+      ("Canonical dir", `Quick, test_basic_dir_canonical);
+      ( "Canonical dir with wildcard",
+        `Quick,
+        test_basic_dir_canonical_with_wildcard );
+    ]
+end
+
 let () =
   Alcotest.run "shark"
-    [ ("basic", Basic.tests); ("command parsing", CommandParsing.tests) ]
+    [
+      ("basic", Basic.tests);
+      ("command parsing", CommandParsing.tests);
+      ("datafile modeling", DataFile.tests);
+    ]

--- a/src/test/test.ml
+++ b/src/test/test.ml
@@ -149,7 +149,7 @@ module DataFile = struct
 
   let test_basic_dir_canonical_with_wildcard () =
     let testcase = "/data/test/" in
-    let test = Shark.Ast.DataFile.v ~subpath:(Some "*") 42 testcase in
+    let test = Shark.Ast.DataFile.v ~subpath:"*" 42 testcase in
     Alcotest.(check int) "Same id" 42 (Shark.Ast.DataFile.id test);
     Alcotest.(check string)
       "Extended path" "/data/test/"

--- a/src/test/test.ml
+++ b/src/test/test.ml
@@ -103,80 +103,11 @@ module CommandParsing = struct
     ]
 end
 
-module DataFile = struct
-  (* let datafile = Alcotest.of_pp Shark.Ast.DataFile.pp *)
-
-  let test_basic_file_path () =
-    let testcase = "/data/test/example.tif" in
-    let test = Shark.Ast.DataFile.v 42 testcase in
-    Alcotest.(check int) "Same id" 42 (Shark.Ast.DataFile.id test);
-    Alcotest.(check string) "Same path" testcase (Shark.Ast.DataFile.path test);
-    Alcotest.(check (option string))
-      "No subpath" None
-      (Shark.Ast.DataFile.subpath test);
-    Alcotest.(check bool)
-      "Isn't wildcard" false
-      (Shark.Ast.DataFile.is_wildcard test);
-    Alcotest.(check bool) "Isn't dir" false (Shark.Ast.DataFile.is_dir test)
-
-  let test_basic_dir_noncanonical () =
-    let testcase = "/data/test" in
-    let test = Shark.Ast.DataFile.v 42 testcase in
-    Alcotest.(check int) "Same id" 42 (Shark.Ast.DataFile.id test);
-    Alcotest.(check string)
-      "Extended path" "/data/test/"
-      (Shark.Ast.DataFile.path test);
-    Alcotest.(check (option string))
-      "No subpath" None
-      (Shark.Ast.DataFile.subpath test);
-    Alcotest.(check bool)
-      "Isn't wildcard" false
-      (Shark.Ast.DataFile.is_wildcard test);
-    Alcotest.(check bool) "Is dir" true (Shark.Ast.DataFile.is_dir test)
-
-  let test_basic_dir_canonical () =
-    let testcase = "/data/test/" in
-    let test = Shark.Ast.DataFile.v 42 testcase in
-    Alcotest.(check int) "Same id" 42 (Shark.Ast.DataFile.id test);
-    Alcotest.(check string) "Same path" testcase (Shark.Ast.DataFile.path test);
-    Alcotest.(check (option string))
-      "No subpath" None
-      (Shark.Ast.DataFile.subpath test);
-    Alcotest.(check bool)
-      "Isn't wildcard" false
-      (Shark.Ast.DataFile.is_wildcard test);
-    Alcotest.(check bool) "Is dir" true (Shark.Ast.DataFile.is_dir test)
-
-  let test_basic_dir_canonical_with_wildcard () =
-    let testcase = "/data/test/" in
-    let test = Shark.Ast.DataFile.v ~subpath:"*" 42 testcase in
-    Alcotest.(check int) "Same id" 42 (Shark.Ast.DataFile.id test);
-    Alcotest.(check string)
-      "Extended path" "/data/test/"
-      (Shark.Ast.DataFile.path test);
-    Alcotest.(check (option string))
-      "No subpath" None
-      (Shark.Ast.DataFile.subpath test);
-    Alcotest.(check bool)
-      "Is wildcard" true
-      (Shark.Ast.DataFile.is_wildcard test);
-    Alcotest.(check bool) "Is dir" true (Shark.Ast.DataFile.is_dir test)
-
-  let tests =
-    [
-      ("Basic file", `Quick, test_basic_file_path);
-      ("Non-canonical dir", `Quick, test_basic_dir_noncanonical);
-      ("Canonical dir", `Quick, test_basic_dir_canonical);
-      ( "Canonical dir with wildcard",
-        `Quick,
-        test_basic_dir_canonical_with_wildcard );
-    ]
-end
-
 let () =
   Alcotest.run "shark"
     [
       ("basic", Basic.tests);
       ("command parsing", CommandParsing.tests);
-      ("datafile modeling", DataFile.tests);
+      ("datafile modeling", Datafile.tests);
+      ("frontmatter parsing", Frontmatter.tests);
     ]


### PR DESCRIPTION
I was mocking up LIFE, and in that there's a dir created from which we select a single file later, and I want to have that flow treated as the dir is an input, with a labelled edge that tells of the specific  file used.

![aoh](https://github.com/quantifyearth/shark/assets/28506/3fbb8ecb-f870-4df9-90f1-4d97a9cbcb32)
