### PR TITLE
Prototype a shark publish block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _build
 .vscode
 shark2.md
+_shark

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ the [promoted output version](./specs/shark.out.md).
 $ patdiff -ascii specs/shark.md specs/shark.out.md
 ------ specs/shark.md
 ++++++ specs/shark.out.md
-@|-1,40 +1,33 ============================================================
+@|-1,40 +1,42 ============================================================
  |
  |# Markdown Shark Support
  |
@@ -93,20 +93,19 @@ $ patdiff -ascii specs/shark.md specs/shark.out.md
 -|```shark-run:gdal-env
 +|```shark-run:gdal-env:e02469d800253ccf95e53b583e4a91465375a4e41479a67408331ecdeedb713e
  |$ cat /data/gdal.version
--|```
--|
--|## Shark Publish
--|
--|Shark allows you to export data directly from the Shark world using a publish block. By default
--|this will publish to a `_shark` directory in the current working directory. Use the same file path
--|conventions to export data blobs.
--|
--|```shark-publish
--|/data/gdal.version
 +|GDAL 3.6.3, released 2023/03/07
 +|
  |```
-+|
+ |
+ |## Shark Publish
+ |
+ |Shark allows you to export data directly from the Shark world using a publish block. By default
+ |this will publish to a `_shark` directory in the current working directory. Use the same file path
+ |conventions to export data blobs.
+ |
+ |```shark-publish
+ |/data/gdal.version
+ |```
 [1]
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ the [promoted output version](./specs/shark.out.md).
 $ patdiff -ascii specs/shark.md specs/shark.out.md
 ------ specs/shark.md
 ++++++ specs/shark.out.md
-@|-1,31 +1,33 ============================================================
+@|-1,40 +1,33 ============================================================
  |
  |# Markdown Shark Support
  |
@@ -93,10 +93,20 @@ $ patdiff -ascii specs/shark.md specs/shark.out.md
 -|```shark-run:gdal-env
 +|```shark-run:gdal-env:e02469d800253ccf95e53b583e4a91465375a4e41479a67408331ecdeedb713e
  |$ cat /data/gdal.version
+-|```
+-|
+-|## Shark Publish
+-|
+-|Shark allows you to export data directly from the Shark world using a publish block. By default
+-|this will publish to a `_shark` directory in the current working directory. Use the same file path
+-|conventions to export data blobs.
+-|
+-|```shark-publish
+-|/data/gdal.version
 +|GDAL 3.6.3, released 2023/03/07
 +|
  |```
- |
++|
 [1]
 ```
 

--- a/specs/shark.md
+++ b/specs/shark.md
@@ -29,3 +29,12 @@ up `/data/gdal.version` into the container.
 $ cat /data/gdal.version
 ```
 
+## Shark Publish
+
+Shark allows you to export data directly from the Shark world using a publish block. By default
+this will publish to a `_shark` directory in the current working directory. Use the same file path
+conventions to export data blobs.
+
+```shark-publish
+/data/gdal.version
+```

--- a/specs/shark.out.md
+++ b/specs/shark.out.md
@@ -31,3 +31,12 @@ GDAL 3.6.3, released 2023/03/07
 
 ```
 
+## Shark Publish
+
+Shark allows you to export data directly from the Shark world using a publish block. By default
+this will publish to a `_shark` directory in the current working directory. Use the same file path
+conventions to export data blobs.
+
+```shark-publish
+/data/gdal.version
+```

--- a/src/lib/ast/ast.ml
+++ b/src/lib/ast/ast.ml
@@ -58,7 +58,7 @@ let parse_frontmatter frontmatter =
    initial benefit. *)
 type section_group = { name : string; children : Block.t list }
 
-let default ~info ~body = Some (Block.v ~alias:info ~body `Run)
+let default ~info ~body = Some (Block.build_or_run ~alias:info ~body `Run)
 
 let parse_markdown markdown =
   let doc = Cmarkit.Doc.of_string markdown in
@@ -292,7 +292,7 @@ let find_id_of_block ast b =
   in
   loop ast.nodes
 
-let find_dependancies ast id =
+let find_dependencies ast id =
   List.filter_map
     (fun (edge : block_id * block_id) : block_id option ->
       let from, too = edge in

--- a/src/lib/ast/ast.mli
+++ b/src/lib/ast/ast.mli
@@ -25,7 +25,7 @@ type t
 
 val of_sharkdown : template_markdown:string -> t
 val find_id_of_block : t -> Block.t -> block_id option
-val find_dependancies : t -> block_id -> Hyperblock.t list
+val find_dependencies : t -> block_id -> Hyperblock.t list
 
 val to_list : t -> Commandgroup.t list
 (** Convert the AST to a list of command blocks. *)

--- a/src/lib/block.mli
+++ b/src/lib/block.mli
@@ -6,21 +6,27 @@ code blocks "language".
 
 After [shark-build] and separated by a [:] there is the build's alias
 which [shark-run] commands can reference in the same way to tell
-{e shark} to use that build environment to execute the command. *)
+{e shark} to use that build environment to execute the command.
+
+[shark-publish] blocks are different. They allow you to export data
+from shark along with its build description. At the moment only
+exporting to the local filesystem is supported. *)
 
 type t
 (** A shark block *)
 
-type kind = [ `Build | `Run ]
-
-val v : ?hash:string -> alias:string -> body:string -> kind -> t
+val build_or_run :
+  ?hash:string -> alias:string -> body:string -> [ `Run | `Build ] -> t
 (** Construct a custom block. *)
+
+val publish : ?output:[ `Directory of string ] -> string -> t
+(** A publish block with a body. Default output is [`Directory "./_shark"] *)
 
 val pp : t Fmt.t
 (** A pretty printer for blocks. *)
 
 val with_hash : t -> string -> t
-(** [with_hash block] is [block] with a new hash. *)
+(** [with_hash block] is [block] with a new hash. Publish blocks remain unchanged. *)
 
 val of_info_string :
   ?default:(info:string -> body:string -> t option) ->
@@ -44,10 +50,11 @@ val alias : t -> string
 val hash : t -> string option
 (** If a block has been run it will hash a build hash *)
 
-val kind : t -> kind
+val kind : t -> [ `Run | `Build | `Publish ]
 (** The kind of block *)
 
 val body : t -> string
 (** The body of the block *)
 
+val output : t -> [ `Directory of string ]
 val digest : t -> string

--- a/src/lib/md.mli
+++ b/src/lib/md.mli
@@ -31,3 +31,9 @@ val process_run_block :
   builder ->
   Cmarkit.Block.Code_block.t * Block.t ->
   (Cmarkit.Block.Code_block.t * Block.t) Lwt.t
+
+val process_publish_block :
+  input_hashes:(string * Datafile.t list) list ->
+  Obuilder.Store_spec.store ->
+  Cmarkit.Block.Code_block.t * Block.t ->
+  (Cmarkit.Block.Code_block.t * Block.t) Lwt.t

--- a/src/test/basic.ml
+++ b/src/test/basic.ml
@@ -2,13 +2,13 @@ let block = Alcotest.of_pp Shark.Block.pp
 
 let test_shark_block () =
   let build_string_no_hash = "shark-build:gdal-env" in
-  let expect = Shark.Block.v ~alias:"gdal-env" ~body:"" `Build in
+  let expect = Shark.Block.build_or_run ~alias:"gdal-env" ~body:"" `Build in
   let test = Shark.Block.of_info_string ~body:"" build_string_no_hash in
   Alcotest.(check (option block)) "same block" (Some expect) test;
 
   let build_string_hash = "shark-build:gdal-env:abcdefg" in
   let expect =
-    Shark.Block.v ~hash:"abcdefg" ~alias:"gdal-env" ~body:"" `Build
+    Shark.Block.build_or_run ~hash:"abcdefg" ~alias:"gdal-env" ~body:"" `Build
   in
   let test = Shark.Block.of_info_string ~body:"" build_string_hash in
   Alcotest.(check (option block)) "same block hash" (Some expect) test;

--- a/src/test/ci.sh
+++ b/src/test/ci.sh
@@ -22,6 +22,8 @@ case "$1" in
         sudo chown "$(whoami)" /rsync
 
         sudo "$GITHUB_WORKSPACE/_build/install/default/bin/shark" md specs/shark.md --store=rsync:/rsync --verbose
+        
+        cat ./_shark/gdal.version
 
         sudo rm -rf /rsync
         ;;


### PR DESCRIPTION
This is a rough prototype for exporting data from Shark. It is very rough. Only exporting to the local filesystem is supported but it reuses the same dependency tracking and the build and run blocks.