### PR TITLE
Track parallel batches better internally to enable publish

### DIFF
--- a/src/lib/ast/ast.ml
+++ b/src/lib/ast/ast.ml
@@ -4,20 +4,21 @@ module DatafileSet = Set.Make (Datafile)
 
 module Hyperblock = struct
   type t = {
-    hash : string option ref;
+    hash : string list ref;
     context : string;
     block : Block.t;
     commands : Leaf.t list;
   }
   [@@deriving sexp]
 
-  let v context block commands = { hash = ref None; context; block; commands }
+  let v context block commands = { hash = ref []; context; block; commands }
   let block h = h.block
   let commands h = h.commands
   let context h = h.context
   let digest h = Block.digest h.block
-  let hash h = !(h.hash)
-  let update_hash h hash = h.hash := Some hash
+  let hash h = match !(h.hash) with [] -> None | hd :: _ -> Some hd
+  let hashes h = !(h.hash)
+  let update_hash h hash = h.hash := hash :: !(h.hash)
 
   let io h =
     let all_inputs, all_outputs =

--- a/src/lib/ast/ast.mli
+++ b/src/lib/ast/ast.mli
@@ -9,6 +9,7 @@ module Hyperblock : sig
 
   val block : t -> Block.t
   val hash : t -> string option
+  val hashes : t -> string list
   val update_hash : t -> string -> unit
   val commands : t -> Leaf.t list
   val context : t -> string


### PR DESCRIPTION
This is a tweak to enable publish of results of a map stage to work, and have the internals better reflect what happened, rather than what I was doing before which was serialising parallel stages for the old internal data structure.