### PR TITLE
Remove as much lwt as possible

### DIFF
--- a/src/lib/md.mli
+++ b/src/lib/md.mli
@@ -23,19 +23,20 @@ val process_build_block :
   builder ->
   Ast.t ->
   Cmarkit.Block.Code_block.t * Block.t ->
-  (Cmarkit.Block.Code_block.t * Block.t) Lwt.t
+  Cmarkit.Block.Code_block.t * Block.t
 
 val process_run_block :
+  fs:_ Eio.Path.t ->
   build_cache:Build_cache.t ->
-  pool:unit Lwt_pool.t ->
+  pool:unit Eio.Pool.t ->
   Obuilder.Store_spec.store ->
   Ast.t ->
   builder ->
   Cmarkit.Block.Code_block.t * Block.t ->
-  (Cmarkit.Block.Code_block.t * Block.t) Lwt.t
+  Cmarkit.Block.Code_block.t * Block.t
 
 val process_publish_block :
   Obuilder.Store_spec.store ->
   Ast.t ->
   Cmarkit.Block.Code_block.t * Block.t ->
-  (Cmarkit.Block.Code_block.t * Block.t) Lwt.t
+  Cmarkit.Block.Code_block.t * Block.t

--- a/src/lib/server/shark_server.ml
+++ b/src/lib/server/shark_server.ml
@@ -457,7 +457,6 @@ let edit_routes ~proc md_file (_conn : Cohttp_eio.Server.conn) request body =
 let router ~proc ~fs ~store md_file (conn : Cohttp_eio.Server.conn) request body
     =
   let open Routes in
-  let store = Lwt_eio.Promise.await_lwt store in
   let routes =
     [
       route nil (serve md_file);


### PR DESCRIPTION
This PR pushes most of the lwt awaits to their actual calls inside the `Md` functions so we don't end up having to do much Lwt gymnastics elsewhere. I also brought across @avsm's suggestion in #34 -- threads is a fine name except in OCaml where it makes users think about system threads and parallelism (yes, Lwt is not a terrific name from this perspective).