### PR TITLE
Basic environmental variables in block working

### DIFF
--- a/src/lib/ast/command.ml
+++ b/src/lib/ast/command.ml
@@ -14,6 +14,7 @@ type t = { name : string; args : string list; file_args : path list }
 
 let pp ppf t = Sexplib.Sexp.pp_hum ppf (sexp_of_t t)
 let v ~name ~args ~file_args = { name; args; file_args }
+let raw_args c = c.args
 let magic_path_regex = Str.regexp "^/data"
 
 let find_file_args args =

--- a/src/lib/ast/command.mli
+++ b/src/lib/ast/command.mli
@@ -9,3 +9,4 @@ val of_string : string -> t option
 val to_string : t -> string
 val name : t -> string
 val file_args : t -> Fpath.t list
+val raw_args : t -> string list

--- a/src/lib/md.ml
+++ b/src/lib/md.ml
@@ -251,7 +251,6 @@ let process_run_block ~fs ~build_cache ~pool store ast
       let ids_and_output_and_cmd, _hash, _pwd =
         List.fold_left outer_process ([], build, "/root") commands
       in
-      let ids_and_output_and_cmd = List.rev ids_and_output_and_cmd in
       let last = List.hd ids_and_output_and_cmd in
       let _, id, _ = List.hd last in
 
@@ -260,7 +259,7 @@ let process_run_block ~fs ~build_cache ~pool store ast
           (fun s (r, _, _) ->
             s @ [ CommandResult.command r; CommandResult.output r ])
           []
-          (List.concat ids_and_output_and_cmd)
+          (List.concat (List.rev ids_and_output_and_cmd))
         |> List.filter (fun v -> not (String.equal "" v))
         |> List.map Cmarkit.Block_line.list_of_string
         |> List.concat


### PR DESCRIPTION
This PR is mostly about adding literal environment variable support to shark. In future these will come from otherwhere, but for now just having anything working is a start.

Additionally this PR also saves errors from the things run in containers to the output sharkdown, and also records what's being copied in a publish stage along with any copy errors there too - this is issue #37 

Oh, and it fixes a bug I added accidentally that broke chaining of blocks with multiple stages.