### PR TITLE
Only use eio_posix to avoid ZFS/uring bugs

### DIFF
--- a/shark.opam
+++ b/shark.opam
@@ -16,7 +16,7 @@ depends: [
   "obuilder-spec"
   "cmarkit"
   "yaml"
-  "eio_main" {>= "1.0"}
+  "eio_posix" {>= "1.0"}
   "lwt_eio"
 
   # Markdown Server

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -351,7 +351,7 @@ let cmds env =
   ]
 
 let () =
-  Eio_main.run @@ fun env ->
+  Eio_posix.run @@ fun env ->
   Mirage_crypto_rng_eio.run (module Mirage_crypto_rng.Fortuna) env @@ fun () ->
   let doc = "a command-line interface for Shark" in
   let info = Cmd.info ~doc "shark" in


### PR DESCRIPTION
Although we haven't hit it yet, the uring backend for Eio has issues on systems using ZFS as their `/` filesystem. `Eio_posix` seems safer.