### PR TITLE
Add monotonic clock times to logs

### DIFF
--- a/src/bin/dune
+++ b/src/bin/dune
@@ -4,6 +4,7 @@
  (libraries
   eio_posix
   shark
+  mtime.clock
   shark.server
   lwt.unix
   obuilder

--- a/src/bin/logging.ml
+++ b/src/bin/logging.ml
@@ -1,0 +1,17 @@
+let reporter clock ppf =
+  let report src level ~over k msgf =
+    let k _ =
+      over ();
+      k ()
+    in
+    let with_stamp h k ppf fmt =
+      let dt = Mtime_clock.count clock |> Mtime.Span.to_uint64_ns in
+      Fmt.kpf k ppf
+        ("[%a] %a %a @[" ^^ fmt ^^ "@]@.")
+        Fmt.uint64_ns_span dt Logs_fmt.pp_header (level, h)
+        Fmt.(styled `Magenta string)
+        (Logs.Src.name src)
+    in
+    msgf @@ fun ?header ?tags:_ fmt -> with_stamp header k ppf fmt
+  in
+  { Logs.report }

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -211,7 +211,7 @@ let setup_log style_renderer level =
   Fmt_tty.setup_std_outputs ?style_renderer ();
   Logs.set_level level;
   Logs.Src.set_level Obuilder.log_src level;
-  Logs.set_reporter (Logs_fmt.reporter ());
+  Logs.set_reporter (Logging.reporter (Mtime_clock.counter ()) Fmt.stdout);
   ()
 
 let setup_log =


### PR DESCRIPTION
Adds a monotonic clock to the logs e.g. 

```
[550ms] [INFO] application Exec "docker" "create" "--" "osgeo/gdal:ubuntu-small-3.6.3"
[603ms] [INFO] application Exec "docker" "export" "--" "33f28c3249dcd4674ef5479ca71a9ddb4fd83d5704aa6eb6ae6394fb1d4e0d5a"
[604ms] [INFO] application Exec "tar" "-C" "/pf341/result/a87ebca984ab9d51fcf691066aba528d2f57b4ab89d7a7921bcc968e3535e6f3/rootfs" "-xf" "-"
[7.65s] [INFO] application Exec "docker" "rm" "--force" "--" "33f28c3249dcd4674ef5479ca71a9ddb4fd83d5704aa6eb6ae6394fb1d4e0d5a"
[7.69s] [INFO] application Exec "docker" "image" "inspect" "--format" "{{range .Config.Env}}{{print . "\x00"}}{{end}}" "--" "osgeo/gdal:ubuntu-small-3.6.3"
[7.72s] [INFO] application Exec "docker" "image" "inspect" "--format" "{{.Config.User}}" "--" "osgeo/gdal:ubuntu-small-3.6.3"
[7.74s] [INFO] application Exec "zfs" "snapshot" "-r" "--" "daintree/pf341/result/a87ebca984ab9d51fcf691066aba528d2f57b4ab89d7a7921bcc968e3535e6f3@snap"
[7.89s] [INFO] application Exec "zfs" "mount" "--" "daintree/pf341/result/a87ebca984ab9d51fcf691066aba528d2f57b4ab89d7a7921bcc968e3535e6f3@snap"
```