### PR TITLE
Simple way to override env vars from command line

### DIFF
--- a/src/lib/md.mli
+++ b/src/lib/md.mli
@@ -27,6 +27,7 @@ val process_build_block :
   Cmarkit.Block.Code_block.t * Block.t
 
 val process_run_block :
+  ?env_override:(string * string) list ->
   fs:_ Eio.Path.t ->
   build_cache:Build_cache.t ->
   pool:unit Eio.Pool.t ->


### PR DESCRIPTION
I just needed this so I could commit the postgis sharkdown demo file I have to the AoH repo. Like docker you can specify multiple -e KEY=VALUE env vars, but they only override ones that are in the sharkdown, they don't add new things (on the grounds we want all state to be explicit in the sharkdown file. The output sharkdown file has the substituted values in it.

I thought of doing this in the AST, but currently we only evaluate shell built-in equivalent commands at execution time, so in the end I went back on that change and just evaluate it at execution time. I'm not wedded to this, it was just the easiest way to get something in. Similarly this could come from a .env file rather than flags or such, but I just needed something of this form fast, so went with args for now.