### PR TITLE
Ignore .shark files in wildcarding

### DIFF
--- a/src/lib/md.ml
+++ b/src/lib/md.ml
@@ -124,7 +124,10 @@ let get_paths ~fs (Obuilder.Store_spec.Store ((module Store), store)) hash
                 (fun (path : string) ->
                   match path with
                   | "." | ".." -> None
-                  | p -> Some (Fpath.add_seg shark_destination_path p))
+                  | p -> (
+                      match Filename.extension p with
+                      | ".shark" -> None
+                      | _ -> Some (Fpath.add_seg shark_destination_path p)))
                 files )
       in
       List.map find_files_in_store outputs


### PR DESCRIPTION
This is a quick workaround for shark wildcard expansion picking up the hidden .shark files pyshark is generating. Not something I think we should do longer term, but it's blocking me right now, so this is a quick work around.

Ideally the pyshark metadata would be on xattr in ZFS, but I had to push it to dot files as shark-publish will lose those. I think longer term I need to have shark-publish take shark xattr data and publish it.

Another option (not necessarily mutually exclusive) is to have  a targeted wildcard where we say "*.geojson" rather than "*" - I think that could be useful, but is the wrong solution here as the user won't except to need to consider the .shark files.