### PR TITLE
Handle failing commands more gracefully

### DIFF
--- a/specs/shark.failure.md
+++ b/specs/shark.failure.md
@@ -1,0 +1,40 @@
+
+# Markdown Shark Support
+
+The `shark` executable also can work with markdown documents. Two blocks can be
+used to run shell-like commands within your markdown documents. The first is
+`shark-build` commands. These allow you to specify a build script that is then
+built and can be referenced as the context for future `shark-run` blocks.
+
+## Shark Build
+
+```shark-build:gdal-env
+((from osgeo/gdal:ubuntu-small-3.6.3)
+ (run (shell "mkdir -p /data && echo 'Something for the log!'")))
+```
+
+Once we have a GDAL environment available to us, we can write shell fragments
+using that environment.
+
+## Shark Run
+
+```shark-run:gdal-env
+$ gdal --version > /data/gdal.version
+```
+
+Shark keeps track of inputs and outputs. In the next code block, Shark knows to wire
+up `/data/gdal.version` into the container.
+
+```shark-run:gdal-env
+$ cat /data/gdal.version
+```
+
+## Shark Publish
+
+Shark allows you to export data directly from the Shark world using a publish block. By default
+this will publish to a `_shark` directory in the current working directory. Use the same file path
+conventions to export data blobs.
+
+```shark-publish
+/data/gdal.version
+```

--- a/src/lib/md.mli
+++ b/src/lib/md.mli
@@ -9,12 +9,15 @@ val map_blocks :
     (build_cache:Build_cache.t ->
     Cmarkit.Block.Code_block.t ->
     Block.t ->
-    Cmarkit.Block.Code_block.t) ->
-  Cmarkit.Doc.t
+    Cmarkit.Block.Code_block.t * [ `Stop of string | `Continue ]) ->
+  Cmarkit.Doc.t * string option
 (** [map_blocks doc ~f] maps over the markdown document picking out shark {! Block.t}s.
     These are then past to [f]. [alias_hash_map] is a list of aliases to hashes (i.e. build
     hashes) that can be used to run blocks with the specific hash of a previous build coming
-    from another block. *)
+    from another block.
+
+    [f] can also halt further processing by returning [`Stop]. The option returned at the
+    end if [`Stop reason] was returned at any point is the [reason]. *)
 
 type builder =
   | Builder : (module Obuilder.BUILDER with type t = 'a) * 'a -> builder
@@ -35,7 +38,7 @@ val process_run_block :
   Ast.t ->
   builder ->
   Cmarkit.Block.Code_block.t * Block.t ->
-  Cmarkit.Block.Code_block.t * Block.t
+  Cmarkit.Block.Code_block.t * Block.t * [ `Stop of string | `Continue ]
 
 val process_publish_block :
   Obuilder.Store_spec.store ->

--- a/src/test/ci.sh
+++ b/src/test/ci.sh
@@ -24,6 +24,13 @@ case "$1" in
         sudo "$GITHUB_WORKSPACE/_build/install/default/bin/shark" md specs/shark.md --store=rsync:/rsync --rsync-mode=hardlink --verbose
         
         cat ./_shark/gdal.version
+        
+		# Expect a failure but with output.
+		if sudo "$GITHUB_WORKSPACE/_build/install/default/bin/shark" md specs/shark.failure.md --store=rsync:/rsync --rsync-mode=hardlink; then
+			exit 1
+		else
+			echo "Successfully Failed"
+		fi
 
         sudo rm -rf /rsync
         ;;

--- a/src/test/ci.sh
+++ b/src/test/ci.sh
@@ -31,8 +31,16 @@ case "$1" in
 		else
 			echo "Successfully Failed"
 		fi
-
-        sudo rm -rf /rsync
+        
+		# We run the failed build twice to check the failure logic.
+		# It should find the failed build, delete it and then fail again.
+		if sudo "$GITHUB_WORKSPACE/_build/install/default/bin/shark" md specs/shark.failure.md --store=rsync:/rsync --rsync-mode=hardlink --verbose; then
+			exit 1
+		else
+			echo "Successfully Failed"
+		fi
+        
+		sudo rm -rf /rsync
         ;;
     *)
         printf "Usage: main.sh [zfs|rsync_copy]" >&2


### PR DESCRIPTION
This PR adds changes OBuilder to keep failed builds in the ZFS and Rsync backends -- for now they are kept and not distinguished from other builds.

On top of this Shark will now stop processing a markdown file once it encounters a failing command. This includes a single failing command inside a map. I would like to change quite substantially how Shark processes maps and builds in general to support this better but for now this seemed sensible as a first PR. The failed command output is promoted back to the code block and the rest of the markdown file is ignored. On exit we print the failing command and the markdown and return a non-zero exit code.

The CI runs a slightly incorrect markdown file where we expect the `gdal --version` command to fail as there is no `gdal` command.