### PR TITLE
Change inputs to being a dictionary in frontmatter, so they can have short names

### DIFF
--- a/src/lib/frontmatter.ml
+++ b/src/lib/frontmatter.ml
@@ -8,7 +8,10 @@ let path_of_sexp = function
 
 let sexp_of_path v = Ppx_sexp_conv_lib.Sexp.Atom (Fpath.to_string v)
 
-type t = { variables : (string * string list) list; inputs : path list }
+type t = {
+  variables : (string * string list) list;
+  inputs : (string * path) list;
+}
 [@@deriving sexp]
 
 let pp ppf t = Sexplib.Sexp.pp_hum ppf (sexp_of_t t)
@@ -16,39 +19,49 @@ let v variables inputs = { variables; inputs }
 let empty = { variables = []; inputs = [] }
 
 let yaml_to_string = function
-  | `String s -> s
+  | `String s -> Some s
   | `Float f ->
-      if Float.is_integer f then int_of_float f |> string_of_int
-      else string_of_float f
-  | _ -> failwith "Can only convert numbers and strings"
+      if Float.is_integer f then Some (int_of_float f |> string_of_int)
+      else Some (string_of_float f)
+  | _ -> None
 
 let string_list_of_yaml = function
-  | `A lst -> List.map yaml_to_string lst
-  | `String s -> [ s ]
-  | yml ->
-      failwith ("Malformed variables in markdown: " ^ Fmt.str "%a" Yaml.pp yml)
+  | `A lst -> Some (List.filter_map yaml_to_string lst)
+  | `String s -> Some [ s ]
+  | _ -> None
 
-let of_yaml = function
+let dict_of_yaml = function `O assoc -> assoc | _ -> []
+
+let of_toplevel_yaml = function
   | `O assoc ->
-      let vars = List.map (fun (k, v) -> (k, string_list_of_yaml v)) assoc in
-      let raw_inputs =
-        match List.assoc_opt "inputs" vars with None -> [] | Some v -> v
+      let vars =
+        List.filter_map
+          (fun (k, v) ->
+            match string_list_of_yaml v with
+            | Some l -> Some (k, l)
+            | None -> None)
+          assoc
+      in
+      let raw_inputs : (string * Yaml.value) list =
+        match List.assoc_opt "inputs" assoc with
+        | None -> []
+        | Some v -> dict_of_yaml v
       in
       let inputs =
-        List.map
-          (fun p ->
-            match Fpath.of_string p with
-            | Error e ->
-                failwith
-                  (Fmt.str "Malformed input path %s"
-                     (match e with `Msg x -> x))
-            | Ok p -> Fpath.normalize p)
+        List.filter_map
+          (fun (k, rp) ->
+            match rp with
+            | `String p -> (
+                match Fpath.of_string p with
+                | Error _ -> None
+                | Ok p -> Some (k, Fpath.normalize p))
+            | _ -> None)
           raw_inputs
       in
       { variables = vars; inputs }
   | `Null -> empty
   | _ -> failwith "Malformed variables in markdown frontmatter"
 
-let of_string s = String.trim s |> Yaml.of_string |> Result.map of_yaml
+let of_string s = String.trim s |> Yaml.of_string |> Result.map of_toplevel_yaml
 let variables t = t.variables
-let inputs t = t.inputs
+let inputs t = List.map (fun (_, v) -> v) t.inputs

--- a/src/lib/frontmatter.mli
+++ b/src/lib/frontmatter.mli
@@ -1,7 +1,7 @@
 type t [@@deriving sexp]
 
 val pp : t Fmt.t
-val v : (string * string list) list -> Fpath.t list -> t
+val v : (string * string list) list -> (string * Fpath.t) list -> t
 val empty : t
 val of_string : string -> (t, [ `Msg of string ]) result
 val variables : t -> (string * string list) list

--- a/src/test/expect/tmf.md
+++ b/src/test/expect/tmf.md
@@ -1,7 +1,7 @@
 ---
 inputs:
-- /data/tmf/project_boundaries/123.geojson
-- /data/tmf/project_boundaries
+  boundary: /data/tmf/project_boundaries/123.geojson
+  projects: /data/tmf/project_boundaries
 ---
 # Running the pipeline
 

--- a/src/test/frontmatter.ml
+++ b/src/test/frontmatter.ml
@@ -8,27 +8,42 @@ let test_empty () =
   Alcotest.(check (result frontmatter msg))
     "Empty expected" (Ok Shark.Frontmatter.empty) res
 
-let test_inputs () =
+let test_parse_inputs () =
   let testcase =
     {|
 inputs:
-- /data/stuff
-- /data/other/
-- /data/file.txt
+  p1: /data/stuff
+  p2: /data/other/
+  p3: /data/file.txt
   |}
   in
   let res = Shark.Frontmatter.of_string testcase in
   let expected =
-    Shark.Frontmatter.v
-      [ ("inputs", [ "/data/stuff"; "/data/other/"; "/data/file.txt" ]) ]
+    Shark.Frontmatter.v []
       [
-        Fpath.v "/data/stuff"; Fpath.v "/data/other/"; Fpath.v "/data/file.txt";
+        ("p1", Fpath.v "/data/stuff");
+        ("p2", Fpath.v "/data/other/");
+        ("p3", Fpath.v "/data/file.txt");
       ]
   in
   Alcotest.(check (result frontmatter msg)) "Empty expected" (Ok expected) res
 
+let test_inputs_api () =
+  let testcase =
+    Shark.Frontmatter.v []
+      [
+        ("p1", Fpath.v "/data/stuff");
+        ("p2", Fpath.v "/data/other/");
+        ("p3", Fpath.v "/data/file.txt");
+      ]
+  in
+  let res = List.map Fpath.to_string (Shark.Frontmatter.inputs testcase) in
+  let expected = [ "/data/stuff"; "/data/other/"; "/data/file.txt" ] in
+  Alcotest.(check (list string)) "Empty expected" expected res
+
 let tests =
   [
     ("empty front matter", `Quick, test_empty);
-    ("simple input list", `Quick, test_inputs);
+    ("simple input list", `Quick, test_parse_inputs);
+    ("simple input api", `Quick, test_inputs_api);
   ]


### PR DESCRIPTION
A pre-cursor to letting you specify input files to be inserted from the command line