### PR TITLE
Make errors in container image builds error and show why

### DIFF
--- a/src/lib/build_cache.ml
+++ b/src/lib/build_cache.ml
@@ -22,6 +22,8 @@ let add t ~alias ~id =
   t.alias_to_build_hash <- (alias, id) :: t.alias_to_build_hash
 
 let with_build t fn =
-  let alias, id, res = fn t in
-  add t ~alias ~id;
-  (alias, id, res)
+  match fn t with
+  | Ok (alias, id, res) ->
+      add t ~alias ~id;
+      Ok (alias, id, res)
+  | Error r -> Error r

--- a/src/lib/build_cache.mli
+++ b/src/lib/build_cache.mli
@@ -13,6 +13,8 @@ val find_exn : t -> string -> Obuilder.S.id
 (** Like {! find} except raises [Failure] if not found *)
 
 val with_build :
-  t -> (t -> string * Obuilder.S.id * 'a) -> string * Obuilder.S.id * 'a
+  t ->
+  (t -> (string * Obuilder.S.id * 'a, string * 'a) result) ->
+  (string * Obuilder.S.id * 'a, string * 'a) result
 (** [with_build t fn] runs [fn] that returns an alias and build ID that
     are added to the build cache store *)

--- a/src/lib/md.mli
+++ b/src/lib/md.mli
@@ -28,7 +28,7 @@ val process_build_block :
   builder ->
   Ast.t ->
   Cmarkit.Block.Code_block.t * Block.t ->
-  Cmarkit.Block.Code_block.t * Block.t
+  Cmarkit.Block.Code_block.t * Block.t * [ `Stop of string | `Continue ]
 
 val process_run_block :
   ?env_override:(string * string) list ->


### PR DESCRIPTION
I went slightly made trying to work out what was going wrong when a pip dependancy updated and make my linter checks in my build spec fail, but shark would just swallow the error and try to build the rest of the pipeline, eventually failing when it tried to use the image it hand't successfully built.

This change:

* Makes progress stop if an image can't be built
* Puts in the markdown the output of the failed build