### PR TITLE
Data visualisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ the [promoted output version](./specs/shark.out.md).
 $ patdiff -ascii specs/shark.md specs/shark.out.md
 ------ specs/shark.md
 ++++++ specs/shark.out.md
-@|-1,40 +1,42 ============================================================
+@|-1,41 +1,43 ============================================================
  |
  |# Markdown Shark Support
  |
@@ -72,8 +72,8 @@ $ patdiff -ascii specs/shark.md specs/shark.out.md
  |## Shark Build
  |
 -|```shark-build:gdal-env
-+|```shark-build:gdal-env:ec610a45b8d858c2eba37fd40dd1764890828557c1c43fa84ec88c7fcdc087c1
- |((from osgeo/gdal:ubuntu-small-3.6.3)
++|```shark-build:gdal-env:4213afafe74bc720d4bb210f21c97d54a361a80a838c248f26dd7dc019a40ac2
+ |((from ghcr.io/osgeo/gdal:ubuntu-small-3.6.3@sha256:bfa7915a3ef942b4f6f61223ee57eadbb469d6fb4a5fbf562286d1473f15eaab)
  | (run (shell "mkdir -p /data && echo 'Something for the log!'")))
  |```
  |
@@ -83,16 +83,20 @@ $ patdiff -ascii specs/shark.md specs/shark.out.md
  |## Shark Run
  |
 -|```shark-run:gdal-env
-+|```shark-run:gdal-env:1dd3d7fdb8f1f485dd5aa0d5f383209a60aca98e67552d03a54c99be8b610eca
- |$ gdalinfo --version > /data/gdal.version
+-|$ gdalinfo --version > /data/gdal.version
+-|$ curl -s https://france-geojson.gregoiredavid.fr/repo/regions/occitanie/region-occitanie.geojson > /data/region-occitanie.geojson
++|```shark-run:gdal-env:8113359387d02c4e29df7013f0cd2d699c4f1303d99fe065204b579baf0dd509
++|gdalinfo --version > /data/gdal.version
++|curl -s https://france-geojson.gregoiredavid.fr/repo/regions/occitanie/region-occitanie.geojson > /data/region-occitanie.geojson
  |```
  |
  |Shark keeps track of inputs and outputs. In the next code block, Shark knows to wire
  |up `/data/gdal.version` into the container.
  |
 -|```shark-run:gdal-env
-+|```shark-run:gdal-env:e02469d800253ccf95e53b583e4a91465375a4e41479a67408331ecdeedb713e
- |$ cat /data/gdal.version
+-|$ cat /data/gdal.version
++|```shark-run:gdal-env:101cf72cd986ca89f23d87c6af4c86908385fd977ebdd4f010ebf6ae8d0b04c6
++|cat /shark/8113359387d02c4e29df7013f0cd2d699c4f1303d99fe065204b579baf0dd509/gdal.version
 +|GDAL 3.6.3, released 2023/03/07
 +|
  |```
@@ -104,7 +108,8 @@ $ patdiff -ascii specs/shark.md specs/shark.out.md
  |conventions to export data blobs.
  |
  |```shark-publish
- |/data/gdal.version
+-|/data/gdal.version
++|/obuilder-zfs/result/8113359387d02c4e29df7013f0cd2d699c4f1303d99fe065204b579baf0dd509/.zfs/snapshot/snap/rootfs/data/gdal.version
  |```
 [1]
 ```

--- a/shark.opam
+++ b/shark.opam
@@ -24,6 +24,8 @@ depends: [
   "htmlit"
   "routes"
   "code-mirror"
+  "magic-mime"
+  "csv"
 
   # Container-image deps / OBuilder
   "mirage-crypto-rng"

--- a/specs/shark.md
+++ b/specs/shark.md
@@ -20,6 +20,7 @@ using that environment.
 
 ```shark-run:gdal-env
 $ gdalinfo --version > /data/gdal.version
+$ curl -s https://france-geojson.gregoiredavid.fr/repo/regions/occitanie/region-occitanie.geojson > /data/region-occitanie.geojson
 ```
 
 Shark keeps track of inputs and outputs. In the next code block, Shark knows to wire

--- a/specs/shark.md
+++ b/specs/shark.md
@@ -9,7 +9,7 @@ built and can be referenced as the context for future `shark-run` blocks.
 ## Shark Build
 
 ```shark-build:gdal-env
-((from osgeo/gdal:ubuntu-small-3.6.3)
+((from ghcr.io/osgeo/gdal:ubuntu-small-3.6.3@sha256:bfa7915a3ef942b4f6f61223ee57eadbb469d6fb4a5fbf562286d1473f15eaab)
  (run (shell "mkdir -p /data && echo 'Something for the log!'")))
 ```
 

--- a/specs/shark.out.md
+++ b/specs/shark.out.md
@@ -8,8 +8,8 @@ built and can be referenced as the context for future `shark-run` blocks.
 
 ## Shark Build
 
-```shark-build:gdal-env
-((from osgeo/gdal:ubuntu-small-3.6.3)
+```shark-build:gdal-env:4213afafe74bc720d4bb210f21c97d54a361a80a838c248f26dd7dc019a40ac2
+((from ghcr.io/osgeo/gdal:ubuntu-small-3.6.3@sha256:bfa7915a3ef942b4f6f61223ee57eadbb469d6fb4a5fbf562286d1473f15eaab)
  (run (shell "mkdir -p /data && echo 'Something for the log!'")))
 ```
 
@@ -18,7 +18,7 @@ using that environment.
 
 ## Shark Run
 
-```shark-run:gdal-env:bf3b13fbfff681b941770ca0e89048afd3e185a2a5f793b63d8728347798f60b
+```shark-run:gdal-env:8113359387d02c4e29df7013f0cd2d699c4f1303d99fe065204b579baf0dd509
 gdalinfo --version > /data/gdal.version
 curl -s https://france-geojson.gregoiredavid.fr/repo/regions/occitanie/region-occitanie.geojson > /data/region-occitanie.geojson
 ```
@@ -26,8 +26,8 @@ curl -s https://france-geojson.gregoiredavid.fr/repo/regions/occitanie/region-oc
 Shark keeps track of inputs and outputs. In the next code block, Shark knows to wire
 up `/data/gdal.version` into the container.
 
-```shark-run:gdal-env:a4438aaea4711bfb05d666f91bb6fa8ba69d0bcd3e4398027538b3346855273b
-cat /shark/bf3b13fbfff681b941770ca0e89048afd3e185a2a5f793b63d8728347798f60b/gdal.version
+```shark-run:gdal-env:101cf72cd986ca89f23d87c6af4c86908385fd977ebdd4f010ebf6ae8d0b04c6
+cat /shark/8113359387d02c4e29df7013f0cd2d699c4f1303d99fe065204b579baf0dd509/gdal.version
 GDAL 3.6.3, released 2023/03/07
 
 ```
@@ -39,5 +39,5 @@ this will publish to a `_shark` directory in the current working directory. Use 
 conventions to export data blobs.
 
 ```shark-publish
-/obuilder-zfs/result/bf3b13fbfff681b941770ca0e89048afd3e185a2a5f793b63d8728347798f60b/.zfs/snapshot/snap/rootfs/data/gdal.version
+/obuilder-zfs/result/8113359387d02c4e29df7013f0cd2d699c4f1303d99fe065204b579baf0dd509/.zfs/snapshot/snap/rootfs/data/gdal.version
 ```

--- a/specs/shark.out.md
+++ b/specs/shark.out.md
@@ -8,7 +8,7 @@ built and can be referenced as the context for future `shark-run` blocks.
 
 ## Shark Build
 
-```shark-build:gdal-env:ec610a45b8d858c2eba37fd40dd1764890828557c1c43fa84ec88c7fcdc087c1
+```shark-build:gdal-env
 ((from osgeo/gdal:ubuntu-small-3.6.3)
  (run (shell "mkdir -p /data && echo 'Something for the log!'")))
 ```
@@ -18,15 +18,16 @@ using that environment.
 
 ## Shark Run
 
-```shark-run:gdal-env:1dd3d7fdb8f1f485dd5aa0d5f383209a60aca98e67552d03a54c99be8b610eca
-$ gdalinfo --version > /data/gdal.version
+```shark-run:gdal-env:bf3b13fbfff681b941770ca0e89048afd3e185a2a5f793b63d8728347798f60b
+gdalinfo --version > /data/gdal.version
+curl -s https://france-geojson.gregoiredavid.fr/repo/regions/occitanie/region-occitanie.geojson > /data/region-occitanie.geojson
 ```
 
 Shark keeps track of inputs and outputs. In the next code block, Shark knows to wire
 up `/data/gdal.version` into the container.
 
-```shark-run:gdal-env:e02469d800253ccf95e53b583e4a91465375a4e41479a67408331ecdeedb713e
-$ cat /data/gdal.version
+```shark-run:gdal-env:a4438aaea4711bfb05d666f91bb6fa8ba69d0bcd3e4398027538b3346855273b
+cat /shark/bf3b13fbfff681b941770ca0e89048afd3e185a2a5f793b63d8728347798f60b/gdal.version
 GDAL 3.6.3, released 2023/03/07
 
 ```
@@ -38,5 +39,5 @@ this will publish to a `_shark` directory in the current working directory. Use 
 conventions to export data blobs.
 
 ```shark-publish
-/data/gdal.version
+/obuilder-zfs/result/bf3b13fbfff681b941770ca0e89048afd3e185a2a5f793b63d8728347798f60b/.zfs/snapshot/snap/rootfs/data/gdal.version
 ```

--- a/src/lib/md.ml
+++ b/src/lib/md.ml
@@ -71,7 +71,7 @@ let process_build_block ?(src_dir = ".") ?hb
           in
           Ast.Hyperblock.update_hash hb id;
           let new_code_block =
-            let info_string = Block.to_info_string block in
+            let info_string = Block.to_info_string block_with_hash in
             Cmarkit.Block.Code_block.make
               ~info_string:(info_string, Cmarkit.Meta.none)
               (Cmarkit.Block.Code_block.code code_block)

--- a/src/lib/server/build.ml
+++ b/src/lib/server/build.ml
@@ -1,0 +1,91 @@
+let ( / ) = Filename.concat
+
+let find_paths pred paths =
+  let rec loop acc = function
+    | `Dir (_, more) -> List.fold_left loop acc more
+    | `File (path, _) -> if pred path then path :: acc else acc
+    | _ -> acc
+  in
+  loop [] paths
+
+(* Rendering Builds *)
+let render (Obuilder.Store_spec.Store ((module Store), store)) id =
+  let result = Lwt_eio.run_lwt (fun () -> Store.result store id) in
+  match result with
+  | None ->
+      Cohttp_eio.Server.respond_string ~status:`OK ~body:("No result for " ^ id)
+        ()
+  | Some path ->
+      let manifest, geojsons, jsons, images, tabular =
+        let src_dir = Fpath.(v path / "rootfs") |> Fpath.to_string in
+        match Obuilder.Manifest.generate ~exclude:[] ~src_dir "data" with
+        | Error (`Msg m) -> (m, [], [], [], [])
+        | Ok src_manifest ->
+            let geojsons =
+              find_paths
+                (fun p -> Filename.extension p = ".geojson")
+                src_manifest
+            in
+            let jsons =
+              find_paths (fun p -> Filename.extension p = ".json") src_manifest
+            in
+            let geojsons =
+              List.map Uri.pct_encode geojsons
+              |> List.map (fun v ->
+                     "." / id
+                     / (Uri.with_query (Uri.of_string "serve")
+                          [ ("file", [ v ]) ]
+                       |> Uri.to_string))
+            in
+            let jsons =
+              List.map
+                (fun v ->
+                  In_channel.with_open_bin (Filename.concat src_dir v)
+                  @@ In_channel.input_all)
+                jsons
+            in
+            let images =
+              find_paths
+                (fun p ->
+                  Filename.extension p = ".png"
+                  || Filename.extension p = ".jpeg")
+                src_manifest
+            in
+            let images =
+              List.map Uri.pct_encode images
+              |> List.map (fun v ->
+                     "." / id
+                     / (Uri.with_query (Uri.of_string "serve")
+                          [ ("file", [ v ]) ]
+                       |> Uri.to_string))
+            in
+            let table =
+              let csvs =
+                find_paths (fun p -> Filename.extension p = ".csv") src_manifest
+              in
+              List.fold_left
+                (fun acc data ->
+                  ( In_channel.with_open_bin (Filename.concat src_dir data)
+                  @@ fun ic -> Csv.load_in ic )
+                  :: acc)
+                [] csvs
+            in
+            ( Obuilder.Manifest.sexp_of_t src_manifest
+              |> Sexplib.Sexp.to_string_hum,
+              geojsons,
+              jsons,
+              images,
+              table )
+      in
+      let page =
+        Pages.build ~geojsons ~jsons ~images ~tabular ~manifest ~title:"Build"
+          ~id ~inputs:[] ()
+      in
+      let body =
+        Cohttp_eio.Body.of_string (Htmlit.El.to_string ~doctype:true page)
+      in
+      let headers =
+        (* Otherwise, an nginx reverse proxy will wait for the whole log before sending anything. *)
+        Cohttp.Header.init_with "X-Accel-Buffering" "no"
+      in
+      Cohttp_eio.Server.respond ~status:`OK ~headers ~body ()

--- a/src/lib/server/build.ml
+++ b/src/lib/server/build.ml
@@ -41,12 +41,7 @@ let render (Obuilder.Store_spec.Store ((module Store), store)) id =
               find_paths (fun p -> Filename.extension p = ".json") src_manifest
             in
             let geojsons =
-              List.map Uri.pct_encode geojsons
-              |> List.map (fun v ->
-                     "." / id
-                     / (Uri.with_query (Uri.of_string "serve")
-                          [ ("file", [ v ]) ]
-                       |> Uri.to_string))
+              List.map (fun g -> Fmt.str "/file/%s/%s" id g) geojsons
             in
             let jsons =
               List.map

--- a/src/lib/server/dune
+++ b/src/lib/server/dune
@@ -14,4 +14,4 @@
 (library
  (name shark_server)
  (public_name shark.server)
- (libraries shark cohttp-eio htmlit routes))
+ (libraries shark cohttp-eio htmlit routes csv))

--- a/src/lib/server/dune
+++ b/src/lib/server/dune
@@ -14,4 +14,4 @@
 (library
  (name shark_server)
  (public_name shark.server)
- (libraries shark cohttp-eio htmlit routes csv))
+ (libraries shark cohttp-eio htmlit routes csv magic-mime))

--- a/src/lib/server/pages.ml
+++ b/src/lib/server/pages.ml
@@ -1,0 +1,342 @@
+let template title body =
+  let open Htmlit in
+  let more_head =
+    El.splice
+      [
+        El.link
+          ~at:
+            [
+              At.rel "stylesheet";
+              At.href
+                "https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/base-min.css";
+            ]
+          ();
+        El.link
+          ~at:
+            [
+              At.rel "stylesheet";
+              At.href
+                "https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/grids-min.css";
+            ]
+          ();
+        El.link
+          ~at:
+            [
+              At.rel "stylesheet";
+              At.href
+                "https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/grids-responsive-min.css";
+            ]
+          ();
+        El.link
+          ~at:
+            [
+              At.rel "stylesheet";
+              At.href
+                "https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/buttons-min.css";
+            ]
+          ();
+        El.link
+          ~at:
+            [
+              At.rel "stylesheet";
+              At.href
+                "https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/tables-min.css";
+            ]
+          ();
+        El.link
+          ~at:
+            [
+              At.rel "stylesheet";
+              At.href "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css";
+            ]
+          ();
+        El.script
+          ~at:[ At.src "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" ]
+          [];
+        El.style
+          [
+            El.unsafe_raw
+              {|
+        body {
+            margin: 24px
+        }
+
+        .l-box {
+            padding: 0em 2em;
+        }
+
+        .pure-g .pure-u-3-5 div {
+            border-right: thin solid grey;
+        }
+
+        #map { width: 100%; height: 800px }
+    |};
+          ];
+      ]
+  in
+  El.page ~lang:"en" ~more_head ~title body
+
+let divc class' children =
+  Htmlit.El.div ~at:[ Htmlit.At.class' class' ] children
+
+let pure_button ?(disabled = false) href txt =
+  Htmlit.El.a
+    ~at:
+      [
+        Htmlit.At.href href;
+        (if disabled then Htmlit.At.disabled else Htmlit.At.void);
+        Htmlit.At.class' "pure-button";
+      ]
+    [ Htmlit.El.txt txt ]
+
+let map geojsons =
+  let open Htmlit in
+  let add =
+    {|fetch(url).then(res => res.json()).then(data => {
+      // add GeoJSON layer to the map once the file is loaded
+      var k = L.geoJson(data, { 
+        style: lineStyle, 
+        minZoom: 3,
+        pointToLayer: function (feature, latlng) {
+        return L.circleMarker(latlng, geojsonMarkerOptions);
+      }});
+      if (i == 0) { map.setView(k.getBounds().getCenter(), 6) };
+      var obj = {};
+      // Extracting filepath from query params of URL
+      var file = new URLSearchParams(url.split("?")[1]).get("file").split("%2F")[1]
+      obj[file] = k;
+      return obj;
+    })|}
+  in
+  let jsarr =
+    Fmt.str "var urls = [ %a ]"
+      Fmt.(list ~sep:(Fmt.any ", ") (quote string))
+      geojsons
+  in
+  El.script
+    [
+      El.unsafe_raw
+        (Fmt.str
+           {|
+      var geojsonMarkerOptions = {
+          radius: 3,
+          fillColor: "#ff0000",
+          color: "#000",
+          weight: 1,
+          opacity: 0.4,
+          fillOpacity: 0.4
+      };
+      var lineStyle = {
+          "color": "#ff7800",
+          "weight": 2,
+          "opacity": 0.3
+      };
+      var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          minZoom: 3,
+          maxZoom: 19,
+          attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+      })
+      var map = L.map('map', {
+        center: [-5.006552150273841, -1.1807189565615772e-05],
+        preferCanvas: true,
+        zoom: 13,
+        minZoom: 3,
+        maxZoom: 13,
+        layers: [ osm ]
+      })
+      %s
+      var proms = urls.map((url, i) => %s)
+      Promise.all(proms).then((layers) => { 
+        var layers = layers.reduce(((r, c) => Object.assign(r, c)), {});
+        console.log(layers);
+        L.control.layers({ "OSM": osm }, layers, {collapsed: false}).addTo(map)
+      })
+    |}
+           jsarr add);
+    ]
+
+module Table = struct
+  type t = string list list
+
+  let render t =
+    let open Htmlit in
+    let row ?(header = false) s =
+      let el = if header then El.th else El.td in
+      El.tr (List.map (fun s -> el [ El.txt s ]) s)
+    in
+    match t with
+    | header :: data ->
+        let header = El.thead [ row ~header:true header ] in
+        El.table
+          ~at:[ At.class' "pure-table" ]
+          [ header; El.tbody (List.map (fun r -> row r) data) ]
+    | _ -> El.txt "Something went wrong rendering the tabluar data"
+end
+
+let build ?(geojsons = []) ?(jsons = []) ?(images = []) ?(tabular = []) ~title
+    ~id ~inputs ~manifest () =
+  let open Htmlit in
+  El.splice
+    [
+      divc "pure-g"
+        [
+          divc "pure-u-3-5"
+            [
+              divc "l-box"
+                [
+                  El.h2 [ El.txt "Data and Build Information" ];
+                  El.em [ El.txt ("Job ID: " ^ id) ];
+                  El.p
+                    [
+                      pure_button "#" "Download Data";
+                      pure_button ~disabled:true "#" "Run Shell";
+                      pure_button ~disabled:true "#" "Run Notebook";
+                    ];
+                  El.p
+                    [
+                      El.txt
+                        "The following files were generated during this build \
+                         step. Clicking 'Download Data' will zip these up and \
+                         begin a download for them. This is only really \
+                         feasible on relatively small datasets.";
+                    ];
+                  El.pre
+                    ~at:[ At.style "height:300px; overflow-y:scroll" ]
+                    [ El.code [ El.txt manifest ] ];
+                  (match geojsons with
+                  | [] -> El.void
+                  | _ ->
+                      El.splice
+                        [
+                          El.h2 [ El.txt "Maps" ];
+                          El.p
+                            [
+                              El.txt
+                                "The map below plots the obviously plottable \
+                                 pieces of data that we could find. For now \
+                                 this is any GeoJSON data files.";
+                            ];
+                          El.p
+                            [
+                              El.em
+                                [
+                                  El.txt
+                                    "Note we've zoomed into bounding box of \
+                                     the first piece of data, the map may \
+                                     contain others!";
+                                ];
+                            ];
+                          El.div ~at:[ At.id "map" ] [];
+                        ]);
+                  (match images with
+                  | [] -> El.void
+                  | urls ->
+                      El.splice
+                        ([
+                           El.h2 [ El.txt "Images" ];
+                           El.p
+                             [
+                               El.txt
+                                 "Images generated as output data, we only \
+                                  render PNG or JPEG images for now as they \
+                                  are likely to be small enough.";
+                             ];
+                         ]
+                        @ List.map
+                            (fun url ->
+                              El.img ~at:[ At.v "width" "100%"; At.src url ] ())
+                            urls));
+                  (match jsons with
+                  | [] -> El.void
+                  | contents ->
+                      El.splice
+                        ([
+                           El.h2 [ El.txt "JSON Files" ];
+                           El.p
+                             [
+                               El.txt
+                                 "Raw JSON files that are not geospatial in \
+                                  nature.";
+                             ];
+                         ]
+                        @ List.map
+                            (fun content ->
+                              El.pre [ El.code [ El.txt content ] ])
+                            contents));
+                  (match tabular with
+                  | [] -> El.void
+                  | datas ->
+                      El.splice
+                        [
+                          El.h2 [ El.txt "Tabular Data" ];
+                          El.p
+                            [
+                              El.txt
+                                "Tables for any CSV files found in the output \
+                                 data directory.";
+                            ];
+                          El.splice (List.map Table.render datas);
+                        ]);
+                ];
+            ];
+          divc "pure-u-2-5"
+            [
+              divc "l-box"
+                [
+                  El.h3 [ El.txt "Build Summary" ];
+                  El.p
+                    [
+                      El.txt
+                        "The following command was the last to be run in this \
+                         pipeline step.";
+                    ];
+                  El.pre
+                    [
+                      El.code [ El.txt "python -m methods.matching.find_pairs" ];
+                    ];
+                  El.h3 [ El.txt "Data Dependencies" ];
+                  El.p
+                    [
+                      El.txt
+                        {|
+              The following list is the immediate data dependencies of this build step.
+              Put another way, these build outputs were made available to this build step
+              in read-only mode. The actual code may or may not have used the data.
+            |};
+                    ];
+                  El.ul
+                    (List.map
+                       (fun i ->
+                         El.li
+                           [ El.a ~at:[ At.href "#" ] [ El.code [ El.txt i ] ] ])
+                       inputs);
+                  El.h3 [ El.txt "Build Specifications" ];
+                  El.p
+                    [
+                      El.txt
+                        "The build specification is a bit like a Dockerfile. \
+                         In this form it is very raw and specific to how the \
+                         dataflow pipeline works, but it has been copied here \
+                         for your convenience.";
+                    ];
+                  El.pre
+                    [
+                      El.code
+                        [
+                          El.txt
+                            {|((from alpine) (run (shell "echo 'hello world'")))|};
+                        ];
+                    ];
+                  El.h3 [ El.txt "Logs" ];
+                  El.p
+                    [
+                      El.txt
+                        {|Raw logs from the build of this particular pipeline step. The data here is very raw, but can help explain how the data was produced.|};
+                    ];
+                  pure_button "./logs" "Raw Logs";
+                ];
+            ];
+        ];
+      (match geojsons with [] -> El.void | lst -> map lst);
+    ]
+  |> template title

--- a/src/lib/server/pages.ml
+++ b/src/lib/server/pages.ml
@@ -164,7 +164,7 @@ let map geojsons =
       if (i == 0) { map.setView(k.getBounds().getCenter(), 6) };
       var obj = {};
       // Extracting filepath from query params of URL
-      var file = new URLSearchParams(url.split("?")[1]).get("file").split("%2F")[1]
+      var file = url.split("/")[url.split("/").length - 1]
       obj[file] = k;
       return obj;
     })|}
@@ -262,7 +262,7 @@ let build ?inputs ?(geojsons = []) ?(jsons = []) ?(images = []) ?(tabular = [])
                          feasible on relatively small datasets.";
                     ];
                   El.pre
-                    ~at:[ At.style "height:300px; overflow-y:scroll" ]
+                    ~at:[ At.style "max-height:300px; overflow-y:scroll" ]
                     [ El.code [ El.txt manifest ] ];
                   (match geojsons with
                   | [] -> El.void

--- a/src/lib/server/shark_server.ml
+++ b/src/lib/server/shark_server.ml
@@ -237,7 +237,7 @@ let custom_document_renderer _ = function
                      ~at:
                        [
                          At.v "target" "_blank";
-                         At.href (Fmt.str "/logs/%s" hash);
+                         At.href (Fmt.str "/data/%s" hash);
                          At.style "text-decoration:none;";
                        ]
                      [
@@ -248,7 +248,7 @@ let custom_document_renderer _ = function
                                "display:inline-flex;align-items:center;padding:0.2em \
                                 0.4em";
                            ]
-                         [ log; El.nbsp; El.txt (Fmt.str "Logs") ];
+                         [ log; El.nbsp; El.txt (Fmt.str "Info") ];
                      ];
                    El.a
                      ~at:
@@ -448,6 +448,38 @@ let serve_dot proc _req body =
 
 let serve_data store id = Build.render store id
 
+let with_file f fn =
+  let open Lwt.Infix in
+  Lwt_unix.openfile f [ Unix.O_RDWR; Unix.O_CREAT ] 0o644 >>= fun fd ->
+  Lwt.finalize (fun () -> fn (f, fd)) (fun () -> Lwt_unix.close fd)
+
+let download ~fs (Obuilder.Store_spec.Store ((module Store), store)) id =
+  match Lwt_eio.run_lwt @@ fun () -> Store.result store id with
+  | None -> Cohttp_eio.Server.respond_string ~status:`Not_found ~body:"" ()
+  | Some src_dir -> (
+      Logs.info (fun f -> f "Download for %s" src_dir);
+      let src_dir = Filename.concat src_dir "rootfs" in
+      match Obuilder.Manifest.generate ~exclude:[] ~src_dir "data" with
+      | Error (`Msg m) ->
+          Cohttp_eio.Server.respond_string ~status:`Bad_request
+            ~body:("Failed data zip: " ^ m) ()
+      | Ok src_manifest ->
+          let fname = Filename.temp_file "tmf-" ".zip" in
+          let tar () =
+            with_file fname @@ fun (_, fd) ->
+            Obuilder.Tar_transfer.send_files ~src_dir
+              ~src_manifest:[ src_manifest ] ~dst_dir:"" ~to_untar:fd
+              ~user:(`Unix Obuilder_spec.{ uid = 1000; gid = 1000 })
+          in
+          let headers =
+            Http.Header.add_opt_unless_exists None "content-type"
+              "application/zip"
+          in
+          (* Some respond_file API would be nice here *)
+          let () = Lwt_eio.run_lwt tar in
+          let body = Cohttp_eio.Body.of_string Eio.Path.(load (fs / fname)) in
+          Cohttp_eio.Server.respond ~status:`OK ~headers ~body ())
+
 let edit_routes ~proc md_file (_conn : Cohttp_eio.Server.conn) request body =
   let open Routes in
   [
@@ -464,6 +496,7 @@ let router ~proc ~fs ~store md_file (conn : Cohttp_eio.Server.conn) request body
       route nil (serve md_file);
       route (s "logs" / str /? nil) (serve_logs fs store);
       route (s "data" / str /? nil) (serve_data store);
+      route (s "download" / str /? nil) (download ~fs store);
       route
         (s "files" / str /? nil)
         (fun hash -> serve_files fs store hash None);

--- a/src/lib/server/shark_server.ml
+++ b/src/lib/server/shark_server.ml
@@ -446,6 +446,8 @@ let serve_dot proc _req body =
   let png = run_dot proc txt |> Base64.encode_string in
   respond_txt png
 
+let serve_data store id = Build.render store id
+
 let edit_routes ~proc md_file (_conn : Cohttp_eio.Server.conn) request body =
   let open Routes in
   [
@@ -461,6 +463,7 @@ let router ~proc ~fs ~store md_file (conn : Cohttp_eio.Server.conn) request body
     [
       route nil (serve md_file);
       route (s "logs" / str /? nil) (serve_logs fs store);
+      route (s "data" / str /? nil) (serve_data store);
       route
         (s "files" / str /? nil)
         (fun hash -> serve_files fs store hash None);


### PR DESCRIPTION
Adds the same basic data visualisation tools as the tmf pipeline. For example, the main `specs/shark.md` now has a little GeoJSON download section in order to render the map.

<img width="1341" alt="Screenshot 2024-07-06 at 18 38 06" src="https://github.com/quantifyearth/shark/assets/20166594/33cb6826-0a84-4468-9596-a07b6bdde585">
